### PR TITLE
Fixed: System.IndexOutOfRangeException when using parameters

### DIFF
--- a/src/Console/Program.cs
+++ b/src/Console/Program.cs
@@ -1132,7 +1132,7 @@ namespace Bit.Console
                     continue;
                 }
 
-                dict.Add(_args[i].Substring(1), _args[i + 1]);
+                dict.Add(_args[i].Substring(1), _args[i]);
             }
 
             return dict;


### PR DESCRIPTION
Issue: "Console.exe sync -f" causes an IndexOutOfRangeException
Workaround: Use "Console.exe sync -f -f"
Fixed: Counter issue at line 1135 "i+1" should be "i"