### PR TITLE
Add support for filtering users based on their group membership

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5009,12 +5009,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5034,7 +5036,8 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -5182,6 +5185,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9924,9 +9928,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
-          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5009,14 +5009,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5036,8 +5034,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -5185,7 +5182,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9928,9 +9924,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",

--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -95,7 +95,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements Direc
                         continue;
                     }
                     const entry = this.buildUser(user);
-                    if (this.filterOutUserResult(setFilter, user)) {
+                    if (await this.filterOutUserResult(setFilter, user)) {
                         continue;
                     }
 
@@ -144,9 +144,9 @@ export class AzureDirectoryService extends BaseDirectoryService implements Direc
             userSetType = UserSetType.IncludeUser;
         } else if (keyword === 'exclude') {
             userSetType = UserSetType.ExcludeUser;
-        } else if (keyword === 'includeGroup') {
+        } else if (keyword === 'includegroup') {
             userSetType = UserSetType.IncludeGroup;
-        } else if (keyword === 'excludeGroup') {
+        } else if (keyword === 'excludegroup') {
             userSetType = UserSetType.ExcludeGroup;
         } else {
             return null;

--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -178,16 +178,20 @@ export class AzureDirectoryService extends BaseDirectoryService implements Direc
                     return false;
                 }
             } else {
-                let memberGroups = await this.client.api(`/users/${user.id}/checkMemberGroups`).post({
-                    groupIds: Array.from(setFilter[1])
-                });
-                if(memberGroups.value.length > 0 && setFilter[0] == UserSetType.IncludeGroup) {
-                    return false;
-                } else if (memberGroups.value.length > 0 && setFilter[0] == UserSetType.ExcludeGroup) {
-                    return true;
-                } else if (memberGroups.value.length == 0 && setFilter[0] == UserSetType.IncludeGroup) {
-                    return true;
-                } else if (memberGroups.value.length == 0 && setFilter[0] == UserSetType.ExcludeGroup) {
+                try {
+                    let memberGroups = await this.client.api(`/users/${user.id}/checkMemberGroups`).post({
+                        groupIds: Array.from(setFilter[1])
+                    });
+                    if (memberGroups.value.length > 0 && setFilter[0] == UserSetType.IncludeGroup) {
+                        return false;
+                    } else if (memberGroups.value.length > 0 && setFilter[0] == UserSetType.ExcludeGroup) {
+                        return true;
+                    } else if (memberGroups.value.length == 0 && setFilter[0] == UserSetType.IncludeGroup) {
+                        return true;
+                    } else if (memberGroups.value.length == 0 && setFilter[0] == UserSetType.ExcludeGroup) {
+                        return false;
+                    }
+                } catch(ex) {
                     return false;
                 }
             }

--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -95,7 +95,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements Direc
                         continue;
                     }
                     const entry = this.buildUser(user);
-                    if (await this.filterOutUserResult(setFilter, user)) {
+                    if (await this.filterOutUserResult(setFilter, entry)) {
                         continue;
                     }
 
@@ -161,7 +161,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements Direc
         return [userSetType, set];
     }
 
-    private async filterOutUserResult(setFilter: [UserSetType, Set<string>], user: graphType.User): Promise<boolean> {
+    private async filterOutUserResult(setFilter: [UserSetType, Set<string>], user: UserEntry): Promise<boolean> {
         if (setFilter != null) {
             let userSetTypeExclude = null;
             if (setFilter[0] === UserSetType.IncludeUser) {
@@ -170,16 +170,10 @@ export class AzureDirectoryService extends BaseDirectoryService implements Direc
                 userSetTypeExclude = true;
             }
             if (userSetTypeExclude != null) {
-                const entry = this.buildUser(user);
-                if (this.filterOutResult([userSetTypeExclude, setFilter[1]], entry.email)) {
-                    return true;
-                }
-                else {
-                    return false;
-                }
+                return this.filterOutResult([userSetTypeExclude, setFilter[1]], user.email);
             } else {
                 try {
-                    let memberGroups = await this.client.api(`/users/${user.id}/checkMemberGroups`).post({
+                    let memberGroups = await this.client.api(`/users/${user.externalId}/checkMemberGroups`).post({
                         groupIds: Array.from(setFilter[1])
                     });
                     if (memberGroups.value.length > 0 && setFilter[0] == UserSetType.IncludeGroup) {


### PR DESCRIPTION
As discussed with the support e-mail, I am creating a pull request to allow filtering users coming from Azure AD based on their group membership.

Basically, back-compatibility with existing filtering is still kept which means that tenants who use the `include:` and `exclude:` keywords will still work fine. I added two keywords `includeGroup:` and `excludeGroup:` which should contain the group ID from Azure Active Directory. With each member found, the Graph endpoint [checkMemberGroups](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/user_checkmembergroups) is called and based on the query result the user is included or excluded.

This PR allows for better synchronization use in environments which have a lot of users including service accounts, B2B guest users etc. in Azure AD who shouldn't be synchronized into Bitwarden's organization.