### PR TITLE
starttls: Support LDAP STARTTLS

### DIFF
--- a/src/app/tabs/settings.component.html
+++ b/src/app/tabs/settings.component.html
@@ -35,22 +35,22 @@
                     </div>
                     <div class="form-group">
                         <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="ldapEncrypted" [(ngModel)]="ldap.encrypted" name="Encrypted">
+                            <input class="form-check-input" type="checkbox" id="ldapEncrypted" [(ngModel)]="ldap.ssl" name="Encrypted">
                             <label class="form-check-label" for="ldapEncrypted">{{'ldapEncrypted' | i18n}}</label>
                         </div>
                     </div>
-                    <div class="ml-4" *ngIf="ldap.encrypted">
+                    <div class="ml-4" *ngIf="ldap.ssl">
                         <div class="form-group">
                             <div class="form-radio">
-                                <input class="form-radio-input" type="radio" value="starttls" id="tls" [(ngModel)]="ldap.encryptionType" name="STARTTLS">
-                                <label class="form-radio-label" for="tls">{{'ldapTls' | i18n}}</label>
+                                <input class="form-radio-input" type="radio"  [value]=true id="starttls" [(ngModel)]="ldap.starttls" name="StartTls">
+                                <label class="form-radio-label" for="starttls">{{'ldapTls' | i18n}}</label>
                             </div>
                             <div class="form-radio">
-                                <input class="form-radio-input" type="radio" value="ssl" id="ssl" [(ngModel)]="ldap.encryptionType" name="SSL">
+                                <input class="form-radio-input" type="radio" [value]=false id="ssl" [(ngModel)]="ldap.starttls"  name="SSL">
                                 <label class="form-radio-label" for="ssl">{{'ldapSsl' | i18n}}</label>
                             </div>
                         </div>
-                        <div class="ml-4" *ngIf="ldap.encryptionType=='starttls'">
+                        <div class="ml-4" *ngIf="ldap.starttls">
                             <p>{{'ldapTlsUntrustedDesc' | i18n}}</p>
                             <div class="form-group">
                                 <label for="tlsCaPath">{{'ldapTlsCa' | i18n}}</label>
@@ -59,7 +59,7 @@
                                 <input type="text" class="form-control" id="tlsCaPath" name="TLSCaPath" [(ngModel)]="ldap.tlsCaPath"> 
                             </div>
                         </div>
-                        <div class="ml-4" *ngIf="ldap.encryptionType=='ssl'">
+                        <div class="ml-4" *ngIf="!ldap.starttls">
                             <p>{{'ldapSslUntrustedDesc' | i18n}}</p>
                             <div class="form-group">
                                 <label for="sslCertPath">{{'ldapSslCert' | i18n}}</label>
@@ -81,7 +81,7 @@
                         <div class="form-group">
                             <div class="form-check">
                                 <input class="form-check-input" type="checkbox" id="certDoNotVerify"
-                                    [(ngModel)]="ldap.certDoNotVerify" name="CertDoNoVerify">
+                                    [(ngModel)]="ldap.sslAllowUnauthorized" name="CertDoNoVerify">
                                 <label class="form-check-label" for="certDoNotVerify">{{'ldapCertDoNotVerify' | i18n}}</label>
                             </div>
                         </div>

--- a/src/app/tabs/settings.component.html
+++ b/src/app/tabs/settings.component.html
@@ -35,39 +35,54 @@
                     </div>
                     <div class="form-group">
                         <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="ssl" [(ngModel)]="ldap.ssl" name="SSL">
-                            <label class="form-check-label" for="ssl">{{'ldapSsl' | i18n}}</label>
+                            <input class="form-check-input" type="checkbox" id="ldapEncrypted" [(ngModel)]="ldap.encrypted" name="Encrypted">
+                            <label class="form-check-label" for="ldapEncrypted">{{'ldapEncrypted' | i18n}}</label>
                         </div>
                     </div>
-                    <div class="ml-4" *ngIf="ldap.ssl">
-                        <p>{{'ldapSslUntrustedDesc' | i18n}}</p>
+                    <div class="ml-4" *ngIf="ldap.encrypted">
                         <div class="form-group">
-                            <label for="sslCertPath">{{'ldapSslCert' | i18n}}</label>
-                            <input type="file" class="form-control-file mb-2" id="sslCertPath_file"
-                                (change)="setSslPath('sslCertPath')">
-                            <input type="text" class="form-control" id="sslCertPath" name="SSLCertPath"
-                                [(ngModel)]="ldap.sslCertPath">
+                            <div class="form-radio">
+                                <input class="form-radio-input" type="radio" value="starttls" id="tls" [(ngModel)]="ldap.encryptionType" name="STARTTLS">
+                                <label class="form-radio-label" for="tls">{{'ldapTls' | i18n}}</label>
+                            </div>
+                            <div class="form-radio">
+                                <input class="form-radio-input" type="radio" value="ssl" id="ssl" [(ngModel)]="ldap.encryptionType" name="SSL">
+                                <label class="form-radio-label" for="ssl">{{'ldapSsl' | i18n}}</label>
+                            </div>
                         </div>
-                        <div class="form-group">
-                            <label for="sslKeyPath">{{'ldapSslKey' | i18n}}</label>
-                            <input type="file" class="form-control-file mb-2" id="sslKeyPath_file"
-                                (change)="setSslPath('sslKeyPath')">
-                            <input type="text" class="form-control" id="sslKeyPath" name="SSLKeyPath"
-                                [(ngModel)]="ldap.sslKeyPath">
+                        <div class="ml-4" *ngIf="ldap.encryptionType=='starttls'">
+                            <p>{{'ldapTlsUntrustedDesc' | i18n}}</p>
+                            <div class="form-group">
+                                <label for="tlsCaPath">{{'ldapTlsCa' | i18n}}</label>
+                                <input type="file" class="form-control-file mb-2" id="tlsCaPath_file"
+                                (change)="setSslPath('tlsCaPath')">
+                                <input type="text" class="form-control" id="tlsCaPath" name="TLSCaPath" [(ngModel)]="ldap.tlsCaPath"> 
+                            </div>
                         </div>
-                        <div class="form-group">
-                            <label for="sslCaPath">{{'ldapSslCa' | i18n}}</label>
-                            <input type="file" class="form-control-file mb-2" id="sslCaPath_file"
-                                (change)="setSslPath('sslCaPath')">
-                            <input type="text" class="form-control" id="sslCaPath" name="SSLCaPath"
-                                [(ngModel)]="ldap.sslCaPath">
+                        <div class="ml-4" *ngIf="ldap.encryptionType=='ssl'">
+                            <p>{{'ldapSslUntrustedDesc' | i18n}}</p>
+                            <div class="form-group">
+                                <label for="sslCertPath">{{'ldapSslCert' | i18n}}</label>
+                                <input type="file" class="form-control-file mb-2" id="sslCertPath_file"
+                                    (change)="setSslPath('sslCertPath')">
+                                <input type="text" class="form-control" id="sslCertPath" name="SSLCertPath" [(ngModel)]="ldap.sslCertPath">
+                            </div>
+                            <div class="form-group">
+                                <label for="sslKeyPath">{{'ldapSslKey' | i18n}}</label>
+                                <input type="file" class="form-control-file mb-2" id="sslKeyPath_file" (change)="setSslPath('sslKeyPath')">
+                                <input type="text" class="form-control" id="sslKeyPath" name="SSLKeyPath" [(ngModel)]="ldap.sslKeyPath">
+                            </div>
+                            <div class="form-group">
+                                <label for="sslCaPath">{{'ldapSslCa' | i18n}}</label>
+                                <input type="file" class="form-control-file mb-2" id="sslCaPath_file" (change)="setSslPath('sslCaPath')">
+                                <input type="text" class="form-control" id="sslCaPath" name="SSLCaPath" [(ngModel)]="ldap.sslCaPath">
+                            </div>
                         </div>
                         <div class="form-group">
                             <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="sslAllowUnauthorized"
-                                    [(ngModel)]="ldap.sslAllowUnauthorized" name="SSLAllowUnauthorized">
-                                <label class="form-check-label"
-                                    for="sslAllowUnauthorized">{{'ldapSslAllowUnauthorized' | i18n}}</label>
+                                <input class="form-check-input" type="checkbox" id="certDoNotVerify"
+                                    [(ngModel)]="ldap.certDoNotVerify" name="CertDoNoVerify">
+                                <label class="form-check-label" for="certDoNotVerify">{{'ldapCertDoNotVerify' | i18n}}</label>
                             </div>
                         </div>
                     </div>

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -414,8 +414,20 @@
     "sync": {
         "message": "Sync"
     },
+    "ldapEncrypted": {
+        "message": "This server uses an encrypted connection"
+    },
+    "ldapTls": {
+        "message": "Use TLS (STARTTLS)"
+    },
+    "ldapTlsCa": {
+        "message": "Certificate CA Chain (PEM)"
+    },
     "ldapSsl": {
-        "message": "This server uses SSL (LDAPS)"
+        "message": "Use SSL (LDAPS)"
+    },
+    "ldapTlsUntrustedDesc": {
+        "message": "If your LDAP server uses a self-signed certificate for STARTTLS, you can configure certificate options below."
     },
     "ldapSslUntrustedDesc": {
         "message": "If your LDAPS server uses an untrusted certificate you can configure certificate options below."
@@ -429,8 +441,8 @@
     "ldapSslKey": {
         "message": "Certificate Private Key (PEM)"
     },
-    "ldapSslAllowUnauthorized": {
-        "message": "Allow untrusted SSL connections (not recommended)."
+    "ldapCertDoNotVerify": {
+        "message": "Do not verify server certificates (not recommended)."
     },
     "ldapAd": {
         "message": "This server uses Active Directory"

--- a/src/models/ldapConfiguration.ts
+++ b/src/models/ldapConfiguration.ts
@@ -1,6 +1,8 @@
 export class LdapConfiguration {
-    ssl = false;
-    sslAllowUnauthorized = false;
+    encrypted = false;
+    encryptionType: string = 'starttls';
+    tlsCaPath: string;
+    certDoNotVerify = false;
     sslCertPath: string;
     sslKeyPath: string;
     sslCaPath: string;

--- a/src/models/ldapConfiguration.ts
+++ b/src/models/ldapConfiguration.ts
@@ -1,8 +1,8 @@
 export class LdapConfiguration {
-    encrypted = false;
-    encryptionType: string = 'starttls';
+    ssl = false;
+    starttls = true;
     tlsCaPath: string;
-    certDoNotVerify = false;
+    sslAllowUnauthorized = false;
     sslCertPath: string;
     sslKeyPath: string;
     sslCaPath: string;

--- a/src/services/ldap-directory.service.ts
+++ b/src/services/ldap-directory.service.ts
@@ -324,7 +324,7 @@ export class LdapDirectoryService implements DirectoryService {
                 reject(this.i18nService.t('dirConfigIncomplete'));
                 return;
             }
-            const protocol = 'ldap' + (this.dirConfig.encrypted && this.dirConfig.encryptionType === 'ssl' ? 's' : '');
+            const protocol = 'ldap' + (this.dirConfig.ssl && !this.dirConfig.starttls ? 's' : '');
             const url = protocol + '://' + this.dirConfig.hostname +
                 ':' + this.dirConfig.port;
             const options: ldap.ClientOptions = {
@@ -332,8 +332,8 @@ export class LdapDirectoryService implements DirectoryService {
             };
 
             const tlsOptions: any = {};
-            if (this.dirConfig.encrypted) {
-                if (this.dirConfig.encryptionType === 'ssl') {
+            if (this.dirConfig.ssl) {
+                if (!this.dirConfig.starttls) {
                     if (this.dirConfig.sslCaPath != null && this.dirConfig.sslCaPath !== '' &&
                         fs.existsSync(this.dirConfig.sslCaPath)) {
                         tlsOptions.ca = [fs.readFileSync(this.dirConfig.sslCaPath)];
@@ -346,14 +346,14 @@ export class LdapDirectoryService implements DirectoryService {
                         fs.existsSync(this.dirConfig.sslKeyPath)) {
                         tlsOptions.key = fs.readFileSync(this.dirConfig.sslKeyPath);
                     }
-                } else if (this.dirConfig.encryptionType === 'starttls') {
+                } else {
                     if (this.dirConfig.tlsCaPath != null && this.dirConfig.tlsCaPath !== '' &&
                         fs.existsSync(this.dirConfig.tlsCaPath)) {
                         tlsOptions.ca = [fs.readFileSync(this.dirConfig.tlsCaPath)];
                     }
                 }
-                if (this.dirConfig.certDoNotVerify != null) {
-                    tlsOptions.rejectUnauthorized = !this.dirConfig.certDoNotVerify;
+                if (this.dirConfig.sslAllowUnauthorized) {
+                    tlsOptions.rejectUnauthorized = !this.dirConfig.sslAllowUnauthorized;
                 }
             }
 
@@ -373,7 +373,7 @@ export class LdapDirectoryService implements DirectoryService {
                 return;
             }
 
-            if (this.dirConfig.encrypted && this.dirConfig.encryptionType === 'starttls') {
+            if (this.dirConfig.starttls && this.dirConfig.ssl) {
                 this.client.starttls(options.tlsOptions, undefined, (err, res) => {
                     if (err != null) {
                         reject(err.message);

--- a/src/services/ldap-directory.service.ts
+++ b/src/services/ldap-directory.service.ts
@@ -324,32 +324,41 @@ export class LdapDirectoryService implements DirectoryService {
                 reject(this.i18nService.t('dirConfigIncomplete'));
                 return;
             }
-
-            const url = 'ldap' + (this.dirConfig.ssl ? 's' : '') + '://' + this.dirConfig.hostname +
+            const protocol = 'ldap' + (this.dirConfig.encrypted && this.dirConfig.encryptionType === 'ssl' ? 's' : '');
+            const url = protocol + '://' + this.dirConfig.hostname +
                 ':' + this.dirConfig.port;
             const options: ldap.ClientOptions = {
                 url: url.trim().toLowerCase(),
             };
-            if (this.dirConfig.ssl) {
-                const tlsOptions: any = {};
-                if (this.dirConfig.sslAllowUnauthorized != null) {
-                    tlsOptions.rejectUnauthorized = !this.dirConfig.sslAllowUnauthorized;
+
+            const tlsOptions: any = {};
+            if (this.dirConfig.encrypted) {
+                if (this.dirConfig.encryptionType === 'ssl') {
+                    if (this.dirConfig.sslCaPath != null && this.dirConfig.sslCaPath !== '' &&
+                        fs.existsSync(this.dirConfig.sslCaPath)) {
+                        tlsOptions.ca = [fs.readFileSync(this.dirConfig.sslCaPath)];
+                    }
+                    if (this.dirConfig.sslCertPath != null && this.dirConfig.sslCertPath !== '' &&
+                        fs.existsSync(this.dirConfig.sslCertPath)) {
+                        tlsOptions.cert = fs.readFileSync(this.dirConfig.sslCertPath);
+                    }
+                    if (this.dirConfig.sslKeyPath != null && this.dirConfig.sslKeyPath !== '' &&
+                        fs.existsSync(this.dirConfig.sslKeyPath)) {
+                        tlsOptions.key = fs.readFileSync(this.dirConfig.sslKeyPath);
+                    }
+                } else if (this.dirConfig.encryptionType === 'starttls') {
+                    if (this.dirConfig.tlsCaPath != null && this.dirConfig.tlsCaPath !== '' &&
+                        fs.existsSync(this.dirConfig.tlsCaPath)) {
+                        tlsOptions.ca = [fs.readFileSync(this.dirConfig.tlsCaPath)];
+                    }
                 }
-                if (this.dirConfig.sslCaPath != null && this.dirConfig.sslCaPath !== '' &&
-                    fs.existsSync(this.dirConfig.sslCaPath)) {
-                    tlsOptions.ca = [fs.readFileSync(this.dirConfig.sslCaPath)];
+                if (this.dirConfig.certDoNotVerify != null) {
+                    tlsOptions.rejectUnauthorized = !this.dirConfig.certDoNotVerify;
                 }
-                if (this.dirConfig.sslCertPath != null && this.dirConfig.sslCertPath !== '' &&
-                    fs.existsSync(this.dirConfig.sslCertPath)) {
-                    tlsOptions.cert = fs.readFileSync(this.dirConfig.sslCertPath);
-                }
-                if (this.dirConfig.sslKeyPath != null && this.dirConfig.sslKeyPath !== '' &&
-                    fs.existsSync(this.dirConfig.sslKeyPath)) {
-                    tlsOptions.key = fs.readFileSync(this.dirConfig.sslKeyPath);
-                }
-                if (Object.keys(tlsOptions).length > 0) {
-                    options.tlsOptions = tlsOptions;
-                }
+            }
+
+            if (Object.keys(tlsOptions).length > 0) {
+                options.tlsOptions = tlsOptions;
             }
 
             this.client = ldap.createClient(options);
@@ -364,13 +373,29 @@ export class LdapDirectoryService implements DirectoryService {
                 return;
             }
 
-            this.client.bind(user, pass, (err) => {
-                if (err != null) {
-                    reject(err.message);
-                } else {
-                    resolve();
-                }
-            });
+            if (this.dirConfig.encrypted && this.dirConfig.encryptionType === 'starttls') {
+                this.client.starttls(options.tlsOptions, undefined, (err, res) => {
+                    if (err != null) {
+                        reject(err.message);
+                    } else {
+                        this.client.bind(user, pass, (err) => {
+                            if (err != null) {
+                                reject(err.message);
+                            } else {
+                                resolve();
+                            }
+                        });
+                    }
+                });
+            } else {
+                this.client.bind(user, pass, (err) => {
+                    if (err != null) {
+                        reject(err.message);
+                    } else {
+                        resolve();
+                    }
+                });
+            }
         });
     }
 


### PR DESCRIPTION
Fixes bitwarden/directory-connector#6
Enables support for STARTTLS on plain LDAP connections, with some UI changes to accommodate both encrypted connection types.

STARTTLS. 

![image](https://user-images.githubusercontent.com/1169963/75621754-c9fa4480-5b98-11ea-99c5-4334fea22343.png)

LDAPS. 

![image](https://user-images.githubusercontent.com/1169963/75621766-ff9f2d80-5b98-11ea-8ce8-c463c71e9d17.png)


