### PR TITLE
Add options for giving passwords and secrets as file contents or in an environment variable

### DIFF
--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -19,6 +19,8 @@ import { SyncConfiguration } from '../models/syncConfiguration';
 
 import { ConnectorUtils } from '../utils';
 
+import { NodeUtils } from 'jslib/misc/nodeUtils';
+
 export class ConfigCommand {
     private directory: DirectoryType;
     private ldap = new LdapConfiguration();
@@ -33,6 +35,13 @@ export class ConfigCommand {
 
     async run(setting: string, value: string, cmd: program.Command): Promise<Response> {
         setting = setting.toLowerCase();
+        if (value == null || value === '') {
+            if (cmd.secretfile) {
+                value = await NodeUtils.readFirstLine(cmd.secretfile);
+            } else if (cmd.secretenv && process.env[cmd.secretenv]) {
+                value = process.env[cmd.secretenv];
+            }
+        }
         try {
             switch (setting) {
                 case 'server':

--- a/src/program.ts
+++ b/src/program.ts
@@ -86,6 +86,8 @@ export class Program extends BaseProgram {
             .description('Log into a user account.')
             .option('--method <method>', 'Two-step login method.')
             .option('--code <code>', 'Two-step login code.')
+            .option('--passwordenv <variable-name>', 'Read password from the named environment variable.')
+            .option('--passwordfile <filename>', 'Read password from first line of the named file.')
             .on('--help', () => {
                 writeLn('\n  Notes:');
                 writeLn('');
@@ -93,9 +95,10 @@ export class Program extends BaseProgram {
                 writeLn('');
                 writeLn('  Examples:');
                 writeLn('');
-                writeLn('    bw login');
-                writeLn('    bw login john@example.com myPassword321');
-                writeLn('    bw login john@example.com myPassword321 --method 1 --code 249213');
+                writeLn('    bwdc login');
+                writeLn('    bwdc login john@example.com myPassword321');
+                writeLn('    bwdc login john@example.com --passwordfile passwd.txt --method 1 --code 249213');
+                writeLn('    bwdc login john@example.com --passwordenv MY_PASSWD --method 1 --code 249213');
                 writeLn('', true);
             })
             .action(async (email: string, password: string, cmd: program.Command) => {
@@ -111,7 +114,7 @@ export class Program extends BaseProgram {
             .on('--help', () => {
                 writeLn('\n  Examples:');
                 writeLn('');
-                writeLn('    bw logout');
+                writeLn('    bwdc logout');
                 writeLn('', true);
             })
             .action(async (cmd) => {
@@ -178,8 +181,10 @@ export class Program extends BaseProgram {
             });
 
         program
-            .command('config <setting> <value>')
+            .command('config <setting> [value]')
             .description('Configure settings.')
+            .option('--secretenv <variable-name>', 'Read secret from the named environment variable.')
+            .option('--secretfile <filename>', 'Read secret from first line of the named file.')
             .on('--help', () => {
                 writeLn('\n  Settings:');
                 writeLn('');
@@ -197,6 +202,7 @@ export class Program extends BaseProgram {
                 writeLn('    bwdc config server bitwarden.com');
                 writeLn('    bwdc config directory 1');
                 writeLn('    bwdc config ldap.password <password>');
+                writeLn('    bwdc config ldap.password --secretenv LDAP_PWD');
                 writeLn('    bwdc config azure.key <key>');
                 writeLn('    bwdc config gsuite.key <key>');
                 writeLn('    bwdc config okta.token <token>');


### PR DESCRIPTION
I would like to avoid giving passwords on command lines. From the command line it would then be written into command histories and visible to other users and processes on the same machine.