### PR TITLE
Added option to let user control the paged param

### DIFF
--- a/src/app/tabs/settings.component.html
+++ b/src/app/tabs/settings.component.html
@@ -33,6 +33,14 @@
                             <label class="form-check-label" for="ad">{{'ldapAd' | i18n}}</label>
                         </div>
                     </div>
+                    <div class="form-group" *ngIf="!ldap.ad">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="pagedSearch"
+                                [(ngModel)]="ldap.pagedSearch" name="PagedSearch">
+                            <label class="form-check-label"
+                                for="pagedSearch">{{'ldapPagedResults' | i18n}}</label>
+                        </div>
+                    </div>
                     <div class="form-group">
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" id="ldapEncrypted" [(ngModel)]="ldap.ssl"

--- a/src/app/tabs/settings.component.ts
+++ b/src/app/tabs/settings.component.ts
@@ -84,6 +84,9 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
     async submit() {
         ConnectorUtils.adjustConfigForSave(this.ldap, this.sync);
+        if (this.ldap != null && this.ldap.ad) {
+            this.ldap.pagedSearch = true;
+        }
         await this.configurationService.saveOrganizationId(this.organizationId);
         await this.configurationService.saveDirectoryType(this.directory);
         await this.configurationService.saveDirectory(DirectoryType.Ldap, this.ldap);

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -447,6 +447,9 @@
     "ldapAd": {
         "message": "This server uses Active Directory"
     },
+    "ldapPagedResults": {
+        "message": "This server pages search results"
+    },
     "select": {
         "message": "Select"
     },

--- a/src/models/ldapConfiguration.ts
+++ b/src/models/ldapConfiguration.ts
@@ -14,4 +14,5 @@ export class LdapConfiguration {
     username: string;
     password: string;
     ad = true;
+    pagedSearch = true;
 }

--- a/src/services/ldap-directory.service.ts
+++ b/src/services/ldap-directory.service.ts
@@ -293,7 +293,7 @@ export class LdapDirectoryService implements DirectoryService {
         const options: ldap.SearchOptions = {
             filter: filter,
             scope: 'sub',
-            paged: false,
+            paged: this.dirConfig.pagedSearch,
         };
         const entries: T[] = [];
         return new Promise<T[]>((resolve, reject) => {


### PR DESCRIPTION
Some LDAP servers have paging turned off. If so, this can cause an error since we made the assumption that all servers are using paging. This change lets the user control that through the settings. This can also be set in the data.json file under directoryConfig_0 > pagedSearch.

For example:


	"directoryConfig_0": {
		...,
		"pagedSearch": true
	},