### PR TITLE
include all members of the g suite group

### DIFF
--- a/src/services/gsuite-directory.service.ts
+++ b/src/services/gsuite-directory.service.ts
@@ -192,9 +192,6 @@ export class GSuiteDirectoryService extends BaseDirectoryService implements Dire
                     if (member.type == null) {
                         continue;
                     }
-                    if (member.role == null || member.role.toLowerCase() !== 'member') {
-                        continue;
-                    }
                     if (member.status == null || member.status.toLowerCase() !== 'active') {
                         continue;
                     }


### PR DESCRIPTION
Users of a group can have roles of owner, manager, and member. Not sure why we were only allowing members to filter through before. We've had a few customers complaining about this. This PR allows all members to be part of the synced group.