### PR TITLE
add support for email coming from username prop

### DIFF
--- a/src/app/tabs/settings.component.html
+++ b/src/app/tabs/settings.component.html
@@ -271,7 +271,8 @@
                             <small class="text-muted form-text">{{'ex' | i18n}} whenChanged</small>
                         </div>
                     </div>
-
+                </div>
+                <div [hidden]="directory != directoryType.Ldap && directory != directoryType.OneLogin">
                     <div class="form-group">
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" id="useEmailPrefixSuffix"
@@ -281,7 +282,7 @@
                         </div>
                     </div>
                     <div [hidden]="!sync.useEmailPrefixSuffix">
-                        <div class="form-group" [hidden]="ldap.ad">
+                        <div class="form-group" [hidden]="ldap.ad || directory != directoryType.Ldap">
                             <label for="emailPrefixAttribute">{{'emailPrefixAttribute' | i18n}}</label>
                             <input type="text" class="form-control" id="emailPrefixAttribute"
                                 name="EmailPrefixAttribute" [(ngModel)]="sync.emailPrefixAttribute">

--- a/src/services/onelogin-directory.service.ts
+++ b/src/services/onelogin-directory.service.ts
@@ -12,8 +12,8 @@ import { DirectoryService } from './directory.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { LogService } from 'jslib/abstractions/log.service';
 
-// Basic email validation: something@somthing.something
-const ValidEmailRegex = /\S+@\S+\.\S+/;
+// Basic email validation: something@something.something
+const ValidEmailRegex = /^\S+@\S+\.\S+$/;
 
 export class OneLoginDirectoryService extends BaseDirectoryService implements DirectoryService {
     private dirConfig: OneLoginConfiguration;
@@ -87,7 +87,7 @@ export class OneLoginDirectoryService extends BaseDirectoryService implements Di
         entry.referenceId = user.id;
         entry.deleted = false;
         entry.disabled = user.status === 2;
-        entry.email = user.email != null ? user.email : null;
+        entry.email = user.email;
         const emailInvalid = (ue: UserEntry) => ue.email == null || ue.email === '';
         if (emailInvalid(entry) && user.username != null && user.username !== '') {
             if (this.validEmailAddress(user.username)) {


### PR DESCRIPTION
OneLogin users may not have a valid email address in the `email` field. According to our customers, a valid email address could also come from the `username` field. Finally, we also fall back to trying to form an email address using the `useEmailPrefixSuffix` sync setting, if enabled.