### PR TITLE
dont skip disabled users if not removeDisabled

### DIFF
--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -70,7 +70,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements Direc
         if (this.syncConfig.groups) {
             const setFilter = this.createCustomSet(this.syncConfig.groupFilter);
             groups = await this.getGroups(setFilter);
-            users = this.filterUsersFromGroupsSet(users, groups, setFilter);
+            users = this.filterUsersFromGroupsSet(users, groups, setFilter, this.syncConfig);
         }
 
         return [groups, users];

--- a/src/services/baseDirectory.service.ts
+++ b/src/services/baseDirectory.service.ts
@@ -1,3 +1,5 @@
+import { SyncConfiguration } from '../models/syncConfiguration';
+
 import { GroupEntry } from '../models/groupEntry';
 import { UserEntry } from '../models/userEntry';
 
@@ -66,13 +68,16 @@ export abstract class BaseDirectoryService {
     }
 
     protected filterUsersFromGroupsSet(users: UserEntry[], groups: GroupEntry[],
-        setFilter: [boolean, Set<string>]): UserEntry[] {
+        setFilter: [boolean, Set<string>], syncConfig: SyncConfiguration): UserEntry[] {
         if (setFilter == null || users == null) {
             return users;
         }
 
         return users.filter((u) => {
-            if (u.disabled || u.deleted) {
+            if (u.deleted) {
+                return true;
+            }
+            if (u.disabled && syncConfig.removeDisabled) {
                 return true;
             }
 

--- a/src/services/gsuite-directory.service.ts
+++ b/src/services/gsuite-directory.service.ts
@@ -58,7 +58,7 @@ export class GSuiteDirectoryService extends BaseDirectoryService implements Dire
         if (this.syncConfig.groups) {
             const setFilter = this.createCustomSet(this.syncConfig.groupFilter);
             groups = await this.getGroups(setFilter);
-            users = this.filterUsersFromGroupsSet(users, groups, setFilter);
+            users = this.filterUsersFromGroupsSet(users, groups, setFilter, this.syncConfig);
         }
 
         return [groups, users];

--- a/src/services/okta-directory.service.ts
+++ b/src/services/okta-directory.service.ts
@@ -59,7 +59,7 @@ export class OktaDirectoryService extends BaseDirectoryService implements Direct
         if (this.syncConfig.groups) {
             const setFilter = this.createCustomSet(this.syncConfig.groupFilter);
             groups = await this.getGroups(this.forceGroup(force, users), setFilter);
-            users = this.filterUsersFromGroupsSet(users, groups, setFilter);
+            users = this.filterUsersFromGroupsSet(users, groups, setFilter, this.syncConfig);
         }
 
         return [groups, users];

--- a/src/services/onelogin-directory.service.ts
+++ b/src/services/onelogin-directory.service.ts
@@ -60,7 +60,7 @@ export class OneLoginDirectoryService extends BaseDirectoryService implements Di
         if (this.syncConfig.groups) {
             const setFilter = this.createCustomSet(this.syncConfig.groupFilter);
             groups = await this.getGroups(this.forceGroup(force, users), setFilter);
-            users = this.filterUsersFromGroupsSet(users, groups, setFilter);
+            users = this.filterUsersFromGroupsSet(users, groups, setFilter, this.syncConfig);
         }
 
         return [groups, users];


### PR DESCRIPTION
This PR fixes a bug where disabled users were not being considered in the `filterUsersFromGroupsSet` function. We would only want to skip disabled users from this filter if we're using the `removeDisabled` setting, which treats disabled users the same as deleted users.