### PR TITLE
[SSO] Added set password flow

### DIFF
--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const { notarize } = require('electron-notarize');
 
 exports.default = async function notarizing(context) {
+    return;
     const { electronPlatformName, appOutDir } = context;
     if (electronPlatformName !== 'darwin') {
         return;

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -2,7 +2,6 @@ require('dotenv').config();
 const { notarize } = require('electron-notarize');
 
 exports.default = async function notarizing(context) {
-    return;
     const { electronPlatformName, appOutDir } = context;
     if (electronPlatformName !== 'darwin') {
         return;

--- a/src/app/accounts/set-password.component.html
+++ b/src/app/accounts/set-password.component.html
@@ -1,105 +1,81 @@
-<form id="set-password-page" #form>
-    <div class="content">
-        <img class="logo-image" alt="Bitwarden">
-        <p class="lead">{{'setMasterPassword' | i18n}}</p>
-        <div class="box">
-            <app-callout type="tip">{{'ssoCompleteRegistration' | i18n}}</app-callout>
-            <app-callout type="info" *ngIf="enforcedPolicyOptions">
-                {{'masterPasswordPolicyInEffect' | i18n}}
-                <ul>
-                    <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
-                        {{'policyInEffectMinComplexity' | i18n : getPasswordScoreAlertDisplay()}}
-                    </li>
-                    <li *ngIf="enforcedPolicyOptions?.minLength > 0">
-                        {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}
-                    </li>
-                    <li *ngIf="enforcedPolicyOptions?.requireUpper">{{'policyInEffectUppercase' | i18n}}</li>
-                    <li *ngIf="enforcedPolicyOptions?.requireLower">{{'policyInEffectLowercase' | i18n}}</li>
-                    <li *ngIf="enforcedPolicyOptions?.requireNumbers">{{'policyInEffectNumbers' | i18n}}</li>
-                    <li *ngIf="enforcedPolicyOptions?.requireSpecial">{{'policyInEffectSpecial' | i18n : '!@#$%^&*'}}
-                    </li>
-                </ul>
-            </app-callout>
-        </div>
-        <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate autocomplete="off">
-            <div class="box">
-                <div class="box-content">
-                    <div class="box-content-row" appBoxRow>
-                        <div class="box-content-row-flex">
-                            <div class="row-main">
-                                <label for="masterPassword">{{'masterPass' | i18n}}
-                                    <strong class="sub-label text-{{masterPasswordScoreColor}}"
-                                        *ngIf="masterPasswordScoreText">
-                                        {{masterPasswordScoreText}}
-                                    </strong>
-                                </label>
+<form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate autocomplete="off">
+    <div class="row justify-content-md-center mt-5">
+        <div class="col-5">
+            <p class="lead text-center mb-4">{{'setMasterPassword' | i18n}}</p>
+            <div class="card d-block">
+                <div class="card-body">
+                    <app-callout type="info">{{'ssoCompleteRegistration' | i18n}}</app-callout>
+                    <div class="form-group">
+                        <app-callout type="info" *ngIf="enforcedPolicyOptions">
+                            {{'masterPasswordPolicyInEffect' | i18n}}
+                            <ul class="mb-0">
+                                <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
+                                    {{'policyInEffectMinComplexity' | i18n : getPasswordScoreAlertDisplay()}}
+                                </li>
+                                <li *ngIf="enforcedPolicyOptions?.minLength > 0">
+                                    {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}
+                                </li>
+                                <li *ngIf="enforcedPolicyOptions?.requireUpper">
+                                    {{'policyInEffectUppercase' | i18n}}</li>
+                                <li *ngIf="enforcedPolicyOptions?.requireLower">
+                                    {{'policyInEffectLowercase' | i18n}}</li>
+                                <li *ngIf="enforcedPolicyOptions?.requireNumbers">
+                                    {{'policyInEffectNumbers' | i18n}}</li>
+                                <li *ngIf="enforcedPolicyOptions?.requireSpecial">
+                                    {{'policyInEffectSpecial' | i18n : '!@#$%^&*'}}</li>
+                            </ul>
+                        </app-callout>
+                        <label for="masterPassword">{{'masterPass' | i18n}}</label>
+                        <div class="d-flex">
+                            <div class="w-100">
                                 <input id="masterPassword" type="{{showPassword ? 'text' : 'password'}}"
-                                    name="MasterPassword" class="monospaced" [(ngModel)]="masterPassword" required
-                                    (input)="updatePasswordStrength()" appInputVerbatim>
+                                    name="MasterPasswordHash" class="text-monospace form-control mb-1"
+                                    [(ngModel)]="masterPassword" (input)="updatePasswordStrength()" required
+                                    appInputVerbatim>
+                                <app-password-strength [score]="masterPasswordScore" [showText]="true">
+                                </app-password-strength>
                             </div>
-                            <div class="action-buttons">
-                                <a class="row-btn" href="#" appStopClick appBlurClick role="button"
+                            <div>
+                                <button type="button" class="ml-1 btn btn-link"
                                     appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword(false)">
                                     <i class="fa fa-lg" aria-hidden="true"
                                         [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
-                                </a>
+                                </button>
+                                <div class="progress-bar invisible"></div>
                             </div>
                         </div>
-                        <div class="progress">
-                            <div class="progress-bar bg-{{masterPasswordScoreColor}}" role="progressbar"
-                                aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"
-                                [ngStyle]="{width: (masterPasswordScoreWidth + '%')}"
-                                attr.aria-valuenow="{{masterPasswordScoreWidth}}">
-                            </div>
+                        <small class="form-text text-muted">{{'masterPassDesc' | i18n}}</small>
+                    </div>
+                    <div class="form-group">
+                        <label for="masterPasswordRetype">{{'reTypeMasterPass' | i18n}}</label>
+                        <div class="d-flex">
+                            <input id="masterPasswordRetype" type="{{showPassword ? 'text' : 'password'}}"
+                                name="MasterPasswordRetype" class="text-monospace form-control"
+                                [(ngModel)]="masterPasswordRetype" required appInputVerbatim>
+                            <button type="button" class="ml-1 btn btn-link" appA11yTitle="{{'toggleVisibility' | i18n}}"
+                                (click)="togglePassword(true)">
+                                <i class="fa fa-lg" aria-hidden="true"
+                                    [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
+                            </button>
                         </div>
                     </div>
-                </div>
-                <div class="box-footer">
-                    {{'masterPassDesc' | i18n}}
-                </div>
-            </div>
-            <div class="box">
-                <div class="box-content">
-                    <div class="box-content-row" appBoxRow>
-                        <div class="box-content-row-flex">
-                            <div class="row-main">
-                                <label for="masterPasswordRetype">{{'reTypeMasterPass' | i18n}}</label>
-                                <input id="masterPasswordRetype" type="password" name="MasterPasswordRetype"
-                                    class="monospaced" [(ngModel)]="masterPasswordRetype" required appInputVerbatim
-                                    autocomplete="new-password">
-                            </div>
-                            <div class="action-buttons">
-                                <a class="row-btn" href="#" appStopClick appBlurClick role="button"
-                                    appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword(true)">
-                                    <i class="fa fa-lg" aria-hidden="true"
-                                        [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="box last">
-                <div class="box-content">
-                    <div class="box-content-row" appBoxRow>
+                    <div class="form-group">
                         <label for="hint">{{'masterPassHint' | i18n}}</label>
-                        <input id="hint" type="text" name="Hint" [(ngModel)]="hint">
+                        <input id="hint" class="form-control" type="text" name="Hint" [(ngModel)]="hint">
+                        <small class="form-text text-muted">{{'masterPassHintDesc' | i18n}}</small>
+                    </div>
+                    <hr>
+                    <div class="d-flex">
+                        <button type="submit" class="btn btn-primary btn-block btn-submit" [disabled]="form.loading">
+                            <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
+                            <span>{{'submit' | i18n}}</span>
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary btn-block ml-2 mt-0" (click)="logOut()">
+                            {{'logOut' | i18n}}
+                        </button>
                     </div>
                 </div>
-                <div class="box-footer">
-                    {{'masterPassHintDesc' | i18n}}
-                </div>
             </div>
-            <div class="buttons">
-                <button type="submit" class="btn primary block" [disabled]="form.loading">
-                    <i *ngIf="form.loading" class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}"
-                        aria-hidden="true"></i>
-                    <span>{{'submit' | i18n}}</span>
-                </button>
-                <button class="btn block" (click)="logOut()">
-                    <span>{{'logOut' | i18n}}</span>
-                </button>
-            </div>
-        </form>
+        </div>
     </div>
 </form>

--- a/src/app/accounts/set-password.component.html
+++ b/src/app/accounts/set-password.component.html
@@ -1,0 +1,105 @@
+<form id="set-password-page" #form>
+    <div class="content">
+        <img class="logo-image" alt="Bitwarden">
+        <p class="lead">{{'setMasterPassword' | i18n}}</p>
+        <div class="box">
+            <app-callout type="tip">{{'ssoCompleteRegistration' | i18n}}</app-callout>
+            <app-callout type="info" *ngIf="enforcedPolicyOptions">
+                {{'masterPasswordPolicyInEffect' | i18n}}
+                <ul>
+                    <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
+                        {{'policyInEffectMinComplexity' | i18n : getPasswordScoreAlertDisplay()}}
+                    </li>
+                    <li *ngIf="enforcedPolicyOptions?.minLength > 0">
+                        {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}
+                    </li>
+                    <li *ngIf="enforcedPolicyOptions?.requireUpper">{{'policyInEffectUppercase' | i18n}}</li>
+                    <li *ngIf="enforcedPolicyOptions?.requireLower">{{'policyInEffectLowercase' | i18n}}</li>
+                    <li *ngIf="enforcedPolicyOptions?.requireNumbers">{{'policyInEffectNumbers' | i18n}}</li>
+                    <li *ngIf="enforcedPolicyOptions?.requireSpecial">{{'policyInEffectSpecial' | i18n : '!@#$%^&*'}}
+                    </li>
+                </ul>
+            </app-callout>
+        </div>
+        <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate autocomplete="off">
+            <div class="box">
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <div class="box-content-row-flex">
+                            <div class="row-main">
+                                <label for="masterPassword">{{'masterPass' | i18n}}
+                                    <strong class="sub-label text-{{masterPasswordScoreColor}}"
+                                        *ngIf="masterPasswordScoreText">
+                                        {{masterPasswordScoreText}}
+                                    </strong>
+                                </label>
+                                <input id="masterPassword" type="{{showPassword ? 'text' : 'password'}}"
+                                    name="MasterPassword" class="monospaced" [(ngModel)]="masterPassword" required
+                                    (input)="updatePasswordStrength()" appInputVerbatim>
+                            </div>
+                            <div class="action-buttons">
+                                <a class="row-btn" href="#" appStopClick appBlurClick role="button"
+                                    appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword(false)">
+                                    <i class="fa fa-lg" aria-hidden="true"
+                                        [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
+                                </a>
+                            </div>
+                        </div>
+                        <div class="progress">
+                            <div class="progress-bar bg-{{masterPasswordScoreColor}}" role="progressbar"
+                                aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"
+                                [ngStyle]="{width: (masterPasswordScoreWidth + '%')}"
+                                attr.aria-valuenow="{{masterPasswordScoreWidth}}">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="box-footer">
+                    {{'masterPassDesc' | i18n}}
+                </div>
+            </div>
+            <div class="box">
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <div class="box-content-row-flex">
+                            <div class="row-main">
+                                <label for="masterPasswordRetype">{{'reTypeMasterPass' | i18n}}</label>
+                                <input id="masterPasswordRetype" type="password" name="MasterPasswordRetype"
+                                    class="monospaced" [(ngModel)]="masterPasswordRetype" required appInputVerbatim
+                                    autocomplete="new-password">
+                            </div>
+                            <div class="action-buttons">
+                                <a class="row-btn" href="#" appStopClick appBlurClick role="button"
+                                    appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword(true)">
+                                    <i class="fa fa-lg" aria-hidden="true"
+                                        [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="box last">
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <label for="hint">{{'masterPassHint' | i18n}}</label>
+                        <input id="hint" type="text" name="Hint" [(ngModel)]="hint">
+                    </div>
+                </div>
+                <div class="box-footer">
+                    {{'masterPassHintDesc' | i18n}}
+                </div>
+            </div>
+            <div class="buttons">
+                <button type="submit" class="btn primary block" [disabled]="form.loading">
+                    <i *ngIf="form.loading" class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}"
+                        aria-hidden="true"></i>
+                    <span>{{'submit' | i18n}}</span>
+                </button>
+                <button class="btn block" (click)="logOut()">
+                    <span>{{'logOut' | i18n}}</span>
+                </button>
+            </div>
+        </form>
+    </div>
+</form>

--- a/src/app/accounts/set-password.component.html
+++ b/src/app/accounts/set-password.component.html
@@ -1,81 +1,90 @@
-<form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate autocomplete="off">
-    <div class="row justify-content-md-center mt-5">
-        <div class="col-5">
-            <p class="lead text-center mb-4">{{'setMasterPassword' | i18n}}</p>
-            <div class="card d-block">
-                <div class="card-body">
-                    <app-callout type="info">{{'ssoCompleteRegistration' | i18n}}</app-callout>
-                    <div class="form-group">
-                        <app-callout type="info" *ngIf="enforcedPolicyOptions">
-                            {{'masterPasswordPolicyInEffect' | i18n}}
-                            <ul class="mb-0">
-                                <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
-                                    {{'policyInEffectMinComplexity' | i18n : getPasswordScoreAlertDisplay()}}
-                                </li>
-                                <li *ngIf="enforcedPolicyOptions?.minLength > 0">
-                                    {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}
-                                </li>
-                                <li *ngIf="enforcedPolicyOptions?.requireUpper">
-                                    {{'policyInEffectUppercase' | i18n}}</li>
-                                <li *ngIf="enforcedPolicyOptions?.requireLower">
-                                    {{'policyInEffectLowercase' | i18n}}</li>
-                                <li *ngIf="enforcedPolicyOptions?.requireNumbers">
-                                    {{'policyInEffectNumbers' | i18n}}</li>
-                                <li *ngIf="enforcedPolicyOptions?.requireSpecial">
-                                    {{'policyInEffectSpecial' | i18n : '!@#$%^&*'}}</li>
-                            </ul>
-                        </app-callout>
-                        <label for="masterPassword">{{'masterPass' | i18n}}</label>
-                        <div class="d-flex">
-                            <div class="w-100">
-                                <input id="masterPassword" type="{{showPassword ? 'text' : 'password'}}"
-                                    name="MasterPasswordHash" class="text-monospace form-control mb-1"
-                                    [(ngModel)]="masterPassword" (input)="updatePasswordStrength()" required
-                                    appInputVerbatim>
-                                <app-password-strength [score]="masterPasswordScore" [showText]="true">
-                                </app-password-strength>
+<div class="container-fluid">
+    <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate autocomplete="off">
+        <div class="row justify-content-center">
+            <div class="col-md-8 col-lg-6">
+                <div class="card d-block">
+                    <h5 class="card-header">{{'setMasterPassword' | i18n}}</h5>
+                    <div class="card-body">
+                        <app-callout type="info">{{'ssoCompleteRegistration' | i18n}}</app-callout>
+                        <div class="form-group">
+                            <app-callout type="info" *ngIf="!enforcedPolicyOptions">
+                                {{'masterPasswordPolicyInEffect' | i18n}}
+                                <ul class="mb-0">
+                                    <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
+                                        {{'policyInEffectMinComplexity' | i18n : getPasswordScoreAlertDisplay()}}
+                                    </li>
+                                    <li *ngIf="enforcedPolicyOptions?.minLength > 0">
+                                        {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}
+                                    </li>
+                                    <li *ngIf="!enforcedPolicyOptions?.requireUpper">
+                                        {{'policyInEffectUppercase' | i18n}}</li>
+                                    <li *ngIf="!enforcedPolicyOptions?.requireLower">
+                                        {{'policyInEffectLowercase' | i18n}}</li>
+                                    <li *ngIf="!enforcedPolicyOptions?.requireNumbers">
+                                        {{'policyInEffectNumbers' | i18n}}</li>
+                                    <li *ngIf="!enforcedPolicyOptions?.requireSpecial">
+                                        {{'policyInEffectSpecial' | i18n : '!@#$%^&*'}}</li>
+                                </ul>
+                            </app-callout>
+                            <label for="masterPassword">{{'masterPass' | i18n}}</label>
+                            <div class="d-flex">
+                                <div class="w-100">
+                                    <input id="masterPassword" type="{{showPassword ? 'text' : 'password'}}"
+                                        name="MasterPasswordHash" class="text-monospace form-control mb-1"
+                                        [(ngModel)]="masterPassword" (input)="updatePasswordStrength()" required
+                                        appInputVerbatim>
+                                    <div class="progress">
+                                        <div class="progress-bar bg-{{masterPasswordScoreColor}}" role="progressbar"
+                                            aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"
+                                            [ngStyle]="{width: (masterPasswordScoreWidth + '%')}"
+                                            attr.aria-valuenow="{{masterPasswordScoreWidth}}">
+                                        </div>
+                                    </div>
+                                </div>
+                                <div>
+                                    <button type="button" class="ml-1 btn btn-link"
+                                        appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword(false)">
+                                        <i class="fa fa-lg" aria-hidden="true"
+                                            [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
+                                    </button>
+                                    <div class="progress-bar invisible"></div>
+                                </div>
                             </div>
-                            <div>
+                            <small class="form-text text-muted">{{'masterPassDesc' | i18n}}</small>
+                        </div>
+                        <div class="form-group">
+                            <label for="masterPasswordRetype">{{'reTypeMasterPass' | i18n}}</label>
+                            <div class="d-flex">
+                                <input id="masterPasswordRetype" type="{{showPassword ? 'text' : 'password'}}"
+                                    name="MasterPasswordRetype" class="text-monospace form-control"
+                                    [(ngModel)]="masterPasswordRetype" required appInputVerbatim>
                                 <button type="button" class="ml-1 btn btn-link"
-                                    appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword(false)">
+                                    appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword(true)">
                                     <i class="fa fa-lg" aria-hidden="true"
                                         [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
                                 </button>
-                                <div class="progress-bar invisible"></div>
                             </div>
                         </div>
-                        <small class="form-text text-muted">{{'masterPassDesc' | i18n}}</small>
-                    </div>
-                    <div class="form-group">
-                        <label for="masterPasswordRetype">{{'reTypeMasterPass' | i18n}}</label>
+                        <div class="form-group">
+                            <label for="hint">{{'masterPassHint' | i18n}}</label>
+                            <input id="hint" class="form-control" type="text" name="Hint" [(ngModel)]="hint">
+                            <small class="form-text text-muted">{{'masterPassHintDesc' | i18n}}</small>
+                        </div>
+                        <hr>
                         <div class="d-flex">
-                            <input id="masterPasswordRetype" type="{{showPassword ? 'text' : 'password'}}"
-                                name="MasterPasswordRetype" class="text-monospace form-control"
-                                [(ngModel)]="masterPasswordRetype" required appInputVerbatim>
-                            <button type="button" class="ml-1 btn btn-link" appA11yTitle="{{'toggleVisibility' | i18n}}"
-                                (click)="togglePassword(true)">
-                                <i class="fa fa-lg" aria-hidden="true"
-                                    [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
+                            <button type="submit" class="btn btn-primary btn-block btn-submit"
+                                [disabled]="form.loading">
+                                <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
+                                <span>{{'submit' | i18n}}</span>
+                            </button>
+                            <button type="button" class="btn btn-outline-secondary btn-block ml-2 mt-0"
+                                (click)="logOut()">
+                                {{'logOut' | i18n}}
                             </button>
                         </div>
-                    </div>
-                    <div class="form-group">
-                        <label for="hint">{{'masterPassHint' | i18n}}</label>
-                        <input id="hint" class="form-control" type="text" name="Hint" [(ngModel)]="hint">
-                        <small class="form-text text-muted">{{'masterPassHintDesc' | i18n}}</small>
-                    </div>
-                    <hr>
-                    <div class="d-flex">
-                        <button type="submit" class="btn btn-primary btn-block btn-submit" [disabled]="form.loading">
-                            <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
-                            <span>{{'submit' | i18n}}</span>
-                        </button>
-                        <button type="button" class="btn btn-outline-secondary btn-block ml-2 mt-0" (click)="logOut()">
-                            {{'logOut' | i18n}}
-                        </button>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
-</form>
+    </form>
+</div>

--- a/src/app/accounts/set-password.component.html
+++ b/src/app/accounts/set-password.component.html
@@ -7,7 +7,7 @@
                     <div class="card-body">
                         <app-callout type="info">{{'ssoCompleteRegistration' | i18n}}</app-callout>
                         <div class="form-group">
-                            <app-callout type="info" *ngIf="!enforcedPolicyOptions">
+                            <app-callout type="info" *ngIf="enforcedPolicyOptions">
                                 {{'masterPasswordPolicyInEffect' | i18n}}
                                 <ul class="mb-0">
                                     <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
@@ -16,17 +16,22 @@
                                     <li *ngIf="enforcedPolicyOptions?.minLength > 0">
                                         {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}
                                     </li>
-                                    <li *ngIf="!enforcedPolicyOptions?.requireUpper">
+                                    <li *ngIf="enforcedPolicyOptions?.requireUpper">
                                         {{'policyInEffectUppercase' | i18n}}</li>
-                                    <li *ngIf="!enforcedPolicyOptions?.requireLower">
+                                    <li *ngIf="enforcedPolicyOptions?.requireLower">
                                         {{'policyInEffectLowercase' | i18n}}</li>
-                                    <li *ngIf="!enforcedPolicyOptions?.requireNumbers">
+                                    <li *ngIf="enforcedPolicyOptions?.requireNumbers">
                                         {{'policyInEffectNumbers' | i18n}}</li>
-                                    <li *ngIf="!enforcedPolicyOptions?.requireSpecial">
+                                    <li *ngIf="enforcedPolicyOptions?.requireSpecial">
                                         {{'policyInEffectSpecial' | i18n : '!@#$%^&*'}}</li>
                                 </ul>
                             </app-callout>
-                            <label for="masterPassword">{{'masterPass' | i18n}}</label>
+                            <label for="masterPassword">{{'masterPass' | i18n}}
+                                <strong class="form-text d-inline-block ml-2 text-{{masterPasswordScoreColor}}"
+                                    *ngIf="masterPasswordScoreText">
+                                    {{masterPasswordScoreText}}
+                                </strong>
+                            </label>
                             <div class="d-flex">
                                 <div class="w-100">
                                     <input id="masterPassword" type="{{showPassword ? 'text' : 'password'}}"
@@ -74,8 +79,9 @@
                         <div class="d-flex">
                             <button type="submit" class="btn btn-primary btn-block btn-submit"
                                 [disabled]="form.loading">
-                                <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
-                                <span>{{'submit' | i18n}}</span>
+                                <i [hidden]="!form.loading" class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}"
+                                    aria-hidden="true"></i>
+                                <span [hidden]="form.loading">{{'submit' | i18n}}</span>
                             </button>
                             <button type="button" class="btn btn-outline-secondary btn-block ml-2 mt-0"
                                 (click)="logOut()">

--- a/src/app/accounts/set-password.component.ts
+++ b/src/app/accounts/set-password.component.ts
@@ -26,6 +26,7 @@ export class SetPasswordComponent extends BaseSetPasswordComponent {
         platformUtilsService: PlatformUtilsService, policyService: PolicyService, router: Router) {
         super(i18nService, cryptoService, messagingService, userService, passwordGenerationService,
             platformUtilsService, policyService, router, apiService);
+        super.successRoute = '/tabs/dashboard';
     }
 
     get masterPasswordScoreWidth() {

--- a/src/app/accounts/set-password.component.ts
+++ b/src/app/accounts/set-password.component.ts
@@ -1,0 +1,68 @@
+import { Component } from '@angular/core';
+
+import {
+    ActivatedRoute,
+    Router,
+} from '@angular/router';
+
+import { ApiService } from 'jslib/abstractions/api.service';
+import { CipherService } from 'jslib/abstractions/cipher.service';
+import { CryptoService } from 'jslib/abstractions/crypto.service';
+import { FolderService } from 'jslib/abstractions/folder.service';
+import { I18nService } from 'jslib/abstractions/i18n.service';
+import { MessagingService } from 'jslib/abstractions/messaging.service';
+import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
+import { SyncService } from 'jslib/abstractions/sync.service';
+import { UserService } from 'jslib/abstractions/user.service';
+
+import {
+    SetPasswordComponent as BaseSetPasswordComponent,
+} from 'jslib/angular/components/set-password.component';
+
+@Component({
+    selector: 'app-set-password',
+    templateUrl: 'set-password.component.html',
+})
+export class SetPasswordComponent extends BaseSetPasswordComponent {
+    constructor(apiService: ApiService, i18nService: I18nService,
+        cryptoService: CryptoService, messagingService: MessagingService,
+        userService: UserService, passwordGenerationService: PasswordGenerationService,
+        platformUtilsService: PlatformUtilsService, folderService: FolderService,
+        cipherService: CipherService, syncService: SyncService,
+        policyService: PolicyService, router: Router, route: ActivatedRoute) {
+        super(apiService, i18nService, cryptoService, messagingService, userService, passwordGenerationService,
+            platformUtilsService, folderService, cipherService, syncService, policyService, router, route);
+    }
+
+    get masterPasswordScoreWidth() {
+        return this.masterPasswordScore == null ? 0 : (this.masterPasswordScore + 1) * 20;
+    }
+
+    get masterPasswordScoreColor() {
+        switch (this.masterPasswordScore) {
+            case 4:
+                return 'success';
+            case 3:
+                return 'primary';
+            case 2:
+                return 'warning';
+            default:
+                return 'danger';
+        }
+    }
+
+    get masterPasswordScoreText() {
+        switch (this.masterPasswordScore) {
+            case 4:
+                return this.i18nService.t('strong');
+            case 3:
+                return this.i18nService.t('good');
+            case 2:
+                return this.i18nService.t('weak');
+            default:
+                return this.masterPasswordScore != null ? this.i18nService.t('weak') : null;
+        }
+    }
+}

--- a/src/app/accounts/set-password.component.ts
+++ b/src/app/accounts/set-password.component.ts
@@ -1,20 +1,14 @@
 import { Component } from '@angular/core';
 
-import {
-    ActivatedRoute,
-    Router,
-} from '@angular/router';
+import { Router } from '@angular/router';
 
 import { ApiService } from 'jslib/abstractions/api.service';
-import { CipherService } from 'jslib/abstractions/cipher.service';
 import { CryptoService } from 'jslib/abstractions/crypto.service';
-import { FolderService } from 'jslib/abstractions/folder.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { PolicyService } from 'jslib/abstractions/policy.service';
-import { SyncService } from 'jslib/abstractions/sync.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
 import {
@@ -29,11 +23,9 @@ export class SetPasswordComponent extends BaseSetPasswordComponent {
     constructor(apiService: ApiService, i18nService: I18nService,
         cryptoService: CryptoService, messagingService: MessagingService,
         userService: UserService, passwordGenerationService: PasswordGenerationService,
-        platformUtilsService: PlatformUtilsService, folderService: FolderService,
-        cipherService: CipherService, syncService: SyncService,
-        policyService: PolicyService, router: Router, route: ActivatedRoute) {
-        super(apiService, i18nService, cryptoService, messagingService, userService, passwordGenerationService,
-            platformUtilsService, folderService, cipherService, syncService, policyService, router, route);
+        platformUtilsService: PlatformUtilsService, policyService: PolicyService, router: Router) {
+        super(i18nService, cryptoService, messagingService, userService, passwordGenerationService,
+            platformUtilsService, policyService, router, apiService);
     }
 
     get masterPasswordScoreWidth() {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -8,6 +8,7 @@ import { AuthGuardService } from './services/auth-guard.service';
 import { LaunchGuardService } from './services/launch-guard.service';
 
 import { LoginComponent } from './accounts/login.component';
+import { SetPasswordComponent } from './accounts/set-password.component';
 import { SsoComponent } from './accounts/sso.component';
 import { TwoFactorComponent } from './accounts/two-factor.component';
 import { DashboardComponent } from './tabs/dashboard.component';
@@ -24,6 +25,7 @@ const routes: Routes = [
     },
     { path: '2fa', component: TwoFactorComponent },
     { path: 'sso', component: SsoComponent },
+    { path: 'set-password', component: SetPasswordComponent },
     {
         path: 'tabs',
         component: TabsComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { TwoFactorOptionsComponent } from './accounts/two-factor-options.compone
 import { TwoFactorComponent } from './accounts/two-factor.component';
 import { DashboardComponent } from './tabs/dashboard.component';
 import { MoreComponent } from './tabs/more.component';
+import { SetPasswordComponent } from './accounts/set-password.component';
 import { SettingsComponent } from './tabs/settings.component';
 import { TabsComponent } from './tabs/tabs.component';
 
@@ -72,6 +73,7 @@ import { SearchCiphersPipe } from 'jslib/angular/pipes/search-ciphers.pipe';
         ModalComponent,
         MoreComponent,
         SearchCiphersPipe,
+        SetPasswordComponent,
         SettingsComponent,
         SsoComponent,
         StopClickDirective,

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -143,7 +143,7 @@ export function initFactory(): Function {
         { provide: ConfigurationService, useValue: configurationService },
         { provide: SyncService, useValue: syncService },
         { provide: PasswordGenerationServiceAbstraction, useValue: passwordGenerationService },
-        { provide: CryptoFunctionServiceAbstraction, useValue: cryptoFunctionService }, ,
+        { provide: CryptoFunctionServiceAbstraction, useValue: cryptoFunctionService },
         { provide: PolicyServiceAbstraction, useValue: policyService },
         {
             provide: APP_INITIALIZER,

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -34,6 +34,7 @@ import { CryptoService } from 'jslib/services/crypto.service';
 import { EnvironmentService } from 'jslib/services/environment.service';
 import { NodeCryptoFunctionService } from 'jslib/services/nodeCryptoFunction.service';
 import { PasswordGenerationService } from 'jslib/services/passwordGeneration.service';
+import { PolicyService } from 'jslib/services/policy.service';
 import { StateService } from 'jslib/services/state.service';
 import { TokenService } from 'jslib/services/token.service';
 import { UserService } from 'jslib/services/user.service';
@@ -51,6 +52,7 @@ import {
     PasswordGenerationService as PasswordGenerationServiceAbstraction,
 } from 'jslib/abstractions/passwordGeneration.service';
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from 'jslib/abstractions/platformUtils.service';
+import { PolicyService as PolicyServiceAbstraction } from 'jslib/abstractions/policy.service';
 import { StateService as StateServiceAbstraction } from 'jslib/abstractions/state.service';
 import { StorageService as StorageServiceAbstraction } from 'jslib/abstractions/storage.service';
 import { TokenService as TokenServiceAbstraction } from 'jslib/abstractions/token.service';
@@ -79,6 +81,7 @@ const configurationService = new ConfigurationService(storageService, secureStor
 const syncService = new SyncService(configurationService, logService, cryptoFunctionService, apiService,
     messagingService, i18nService);
 const passwordGenerationService = new PasswordGenerationService(cryptoService, storageService, null);
+const policyService = new PolicyService(userService, storageService);
 
 const analytics = new Analytics(window, () => true, platformUtilsService, storageService, appIdService);
 containerService.attachToWindow(window);
@@ -140,7 +143,8 @@ export function initFactory(): Function {
         { provide: ConfigurationService, useValue: configurationService },
         { provide: SyncService, useValue: syncService },
         { provide: PasswordGenerationServiceAbstraction, useValue: passwordGenerationService },
-        { provide: CryptoFunctionServiceAbstraction, useValue: cryptoFunctionService },
+        { provide: CryptoFunctionServiceAbstraction, useValue: cryptoFunctionService }, ,
+        { provide: PolicyServiceAbstraction, useValue: policyService },
         {
             provide: APP_INITIALIZER,
             useFactory: initFactory,

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -680,5 +680,41 @@
     },
     "masterPassHintDesc": {
         "message": "A master password hint can help you remember your password if you forget it."
+    },
+    "strong": {
+        "message": "Strong",
+        "description": "ex. A strong password. Scale: Weak -> Good -> Strong"
+    },
+    "good": {
+        "message": "Good",
+        "description": "ex. A good password. Scale: Weak -> Good -> Strong"
+    },
+    "weak": {
+        "message": "Weak",
+        "description": "ex. A weak password. Scale: Weak -> Good -> Strong"
+    },
+    "weakMasterPassword": {
+        "message": "Weak Master Password"
+    },
+    "weakMasterPasswordDesc": {
+        "message": "The master password you have chosen is weak. You should use a strong master password (or a passphrase) to properly protect your Bitwarden account. Are you sure you want to use this master password?"
+    },
+    "errorOccurred": {
+        "message": "An error has occurred."
+    },
+    "error": {
+        "message": "Error"
+    },
+    "masterPassLength": {
+        "message": "Master password must be at least 8 characters long."
+    },
+    "masterPassDoesntMatch": {
+        "message": "Master password confirmation does not match."
+    },
+    "masterPasswordPolicyRequirementsNotMet": {
+        "message": "Your new master password does not meet the policy requirements."
+    },
+    "loading": {
+        "message": "Loading"
     }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -617,5 +617,68 @@
     },
     "enterpriseSingleSignOn": {
         "message": "Enterprise Single Sign-On"
+    },
+    "setMasterPassword": {
+        "message": "Set Master Password"
+    },
+    "ssoCompleteRegistration": {
+        "message": "In order to complete logging in with SSO, please set a master password to access and protect your vault."
+    },
+    "newMasterPass": {
+        "message": "New Master Password"
+    },
+    "confirmNewMasterPass": {
+        "message": "Confirm New Master Password"
+    },
+    "masterPasswordPolicyInEffect": {
+        "message": "One or more organization policies require your master password to meet the following requirements:"
+    },
+    "policyInEffectMinComplexity": {
+        "message": "Minimum complexity score of $SCORE$",
+        "placeholders": {
+            "score": {
+                "content": "$1",
+                "example": "4"
+            }
+        }
+    },
+    "policyInEffectMinLength": {
+        "message": "Minimum length of $LENGTH$",
+        "placeholders": {
+            "length": {
+                "content": "$1",
+                "example": "14"
+            }
+        }
+    },
+    "policyInEffectUppercase": {
+        "message": "Contain one or more uppercase characters"
+    },
+    "policyInEffectLowercase": {
+        "message": "Contain one or more lowercase characters"
+    },
+    "policyInEffectNumbers": {
+        "message": "Contain one or more numbers"
+    },
+    "policyInEffectSpecial": {
+        "message": "Contain one or more of the following special characters $CHARS$",
+        "placeholders": {
+            "chars": {
+                "content": "$1",
+                "example": "!@#$%^&*"
+            }
+        }
+    },
+    "masterPassDesc": {
+        "message": "The master password is the password you use to access your vault. It is very important that you do not forget your master password. There is no way to recover the password in the event that you forget it."
+    },
+    "reTypeMasterPass": {
+        "message": "Re-type Master Password"
+    },
+    "masterPassHint": {
+        "message": "Master Password Hint (optional)"
+    },
+    "masterPassHintDesc": {
+        "message": "A master password hint can help you remember your password if you forget it."
     }
 }

--- a/src/scss/bootstrap.scss
+++ b/src/scss/bootstrap.scss
@@ -1,4 +1,4 @@
-$theme-colors: ( "primary": #175DDC, "primary-accent": #1252A3, "danger": #dd4b39, "success": #00a65a, "info": #555555, "warning": #bf7e16);
+$theme-colors: ( "primary": #175DDC, "primary-accent": #1252A3, "danger": #dd4b39, "success": #00a65a, "info": #555555, "warning": #bf7e16, "secondary": #ced4da, "secondary-alt": #1A3B66);
 $font-family-sans-serif: 'Open Sans','Helvetica Neue',Helvetica,Arial,sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 
 $h1-font-size: 2rem;
@@ -7,5 +7,14 @@ $h3-font-size: 1rem;
 $h4-font-size: 1rem;
 $h5-font-size: 1rem;
 $h6-font-size: 1rem;
+
+$primary: map_get($theme-colors, 'primary'); 
+$primary-accent: map_get($theme-colors, 'primary-accent'); 
+$success: map_get($theme-colors, 'success'); 
+$info: map_get($theme-colors, 'info'); 
+$warning: map_get($theme-colors, 'warning'); 
+$danger: map_get($theme-colors, 'danger'); 
+$secondary: map_get($theme-colors, 'secondary'); 
+$secondary-alt: map_get($theme-colors, 'secondary-alt'); 
 
 @import "~bootstrap/scss/bootstrap.scss";

--- a/src/scss/misc.scss
+++ b/src/scss/misc.scss
@@ -76,7 +76,7 @@ ul.testing-list {
         border-left-color: $primary;
 
         .callout-heading {
-                color: $primary;
+            color: $primary;
         }
     }
 
@@ -84,7 +84,7 @@ ul.testing-list {
         border-left-color: $info;
 
         .callout-heading {
-                color: $info; 
+            color: $info; 
         }
     }
 
@@ -100,7 +100,7 @@ ul.testing-list {
         border-left-color: $success;
 
         .callout-heading {
-                color: $success;
+            color: $success;
         }
     }
 

--- a/src/scss/misc.scss
+++ b/src/scss/misc.scss
@@ -53,3 +53,68 @@ ul.testing-list {
         text-decoration: line-through;
     }
 }
+
+.callout {
+    padding: 10px;
+    margin-bottom: 10px;
+    border: 1px solid #000000;
+    border-left-width: 5px;
+    border-radius: 3px;
+    border-color: #ddd;
+    background-color: white;
+
+    .callout-heading {
+        margin-top: 0;
+    }
+
+    h3.callout-heading {
+        font-weight: bold;
+        text-transform: uppercase;
+    }
+
+    &.callout-primary {
+        border-left-color: $primary;
+
+        .callout-heading {
+                color: $primary;
+        }
+    }
+
+    &.callout-info {
+        border-left-color: $info;
+
+        .callout-heading {
+                color: $info; 
+        }
+    }
+
+    &.callout-danger {
+        border-left-color: $danger;
+
+        .callout-heading {
+            color: $danger;
+        }
+    }
+
+    &.callout-success {
+        border-left-color: $success;
+
+        .callout-heading {
+                color: $success;
+        }
+    }
+
+    &.callout-warning {
+        border-left-color: $warning;
+
+        .callout-heading {
+            color: $warning;
+        }
+    }
+
+    ul {
+        padding-left: 40px;
+        margin: 0;
+    }
+}
+


### PR DESCRIPTION
## Objective
> Added the sso set password flow into the directory connector. Make sure password validation is in place and that a successful update lands you on the dashboard page.

## Code Changes
- **jslib**: Update from 5d874d0 to 6ab444a
- **set-password.component.html**: Created UI (similar to boostrap'd web layout)
- **set-password.component.ts**: Added class to handle set password flow. Updated success route to land on the dashboard. Added password strength local functions.
- **app-routing.module.ts**: Added `set-password` for routing capabilities
- **app.module.ts**: Added `set-password` component for compilation/use
- **services.module.ts**: Added `policy.service` provider (needed for enforcing policy options within super class `change-password`)
- **messages.json**: Added all missing strings
- **misc.scss**: Add `callout` (un-themed) stylization

## Screenshot
<img width="895" alt="Screen Shot 2020-08-22 at 2 15 40 PM" src="https://user-images.githubusercontent.com/26154748/90964309-09895580-e485-11ea-825f-63ecfa2d599f.png">
**Fixed Theme Colors**
<img width="566" alt="Screen Shot 2020-08-24 at 11 49 35 AM" src="https://user-images.githubusercontent.com/26154748/91073068-167e8400-e600-11ea-92cb-ee15b16c9ca0.png">
