### PR TITLE
[SSO] Adjusted 2fa success route

### DIFF
--- a/src/app/accounts/two-factor.component.ts
+++ b/src/app/accounts/two-factor.component.ts
@@ -36,6 +36,10 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
         storageService: StorageService) {
         super(authService, router, i18nService, apiService, platformUtilsService, window, environmentService,
             stateService, storageService);
+    }
+
+    async ngOnInit() {
+        super.ngOnInit();
         super.successRoute = '/tabs/dashboard';
     }
 


### PR DESCRIPTION
## Objective
>When logging in with SSO in the Directory Connector from a user account that has 2FA enabled the 2FA code input page does not close on successful validation. Additional details [here](https://app.asana.com/0/1188746734054362/1192839560133337)

## Steps to reproduce:
1. Log in to Directory Connector via SSO with a user account using 2FA
2. Enter the validation code from your 2FA app and click submit
3. The 2FA validation screen will not close unless "Cancel" is clicked. 

## Code Changes
 - **two-factor.component.ts**: Adjusted where we set the success route to be after `super.ngOnInit()`.