### PR TITLE
[SSO] New user provision flow jslib update (5e0a2d1 -> d84d6da)

### DIFF
--- a/src/app/accounts/two-factor.component.ts
+++ b/src/app/accounts/two-factor.component.ts
@@ -5,7 +5,10 @@ import {
     ViewContainerRef,
 } from '@angular/core';
 
-import { Router } from '@angular/router';
+import {
+    ActivatedRoute,
+    Router,
+} from '@angular/router';
 
 import { TwoFactorOptionsComponent } from './two-factor-options.component';
 
@@ -33,9 +36,9 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
         i18nService: I18nService, apiService: ApiService,
         platformUtilsService: PlatformUtilsService, environmentService: EnvironmentService,
         private componentFactoryResolver: ComponentFactoryResolver, stateService: StateService,
-        storageService: StorageService) {
+        storageService: StorageService, route: ActivatedRoute) {
         super(authService, router, i18nService, apiService, platformUtilsService, window, environmentService,
-            stateService, storageService);
+            stateService, storageService, route);
     }
 
     async ngOnInit() {


### PR DESCRIPTION
## Objective
> Currently, when a new bitwarden/org user is created, they are given a status of accepted. This can create issues for organizations trying to confirm the same user (which can't happen until they've set their master password). To alleviate the issue, change new user's orgUser status to invited until after they've set a master password.

## Code Changes
- **jslib**: Update from 5e0a2d1 to d84d6da
- **two-factor.component.ts**: Update import/constructor to pass in active route