### PR TITLE
Add logger to lowdb storage service

### DIFF
--- a/src/bwdc.ts
+++ b/src/bwdc.ts
@@ -80,7 +80,7 @@ export class Main {
         this.logService = new ConsoleLogService(this.platformUtilsService.isDev(),
             (level) => process.env.BITWARDENCLI_CONNECTOR_DEBUG !== 'true' && level <= LogLevelType.Info);
         this.cryptoFunctionService = new NodeCryptoFunctionService();
-        this.storageService = new LowdbStorageService(null, this.dataFilePath, true);
+        this.storageService = new LowdbStorageService(this.logService, null, this.dataFilePath, true);
         this.secureStorageService = plaintextSecrets ?
             this.storageService : new KeytarSecureStorageService(applicationName);
         this.cryptoService = new CryptoService(this.storageService, this.secureStorageService,


### PR DESCRIPTION
Adds ability to get to next steps on #41 ; `jslib` update to commit hash is from https://github.com/bitwarden/jslib/pull/188

## Overview
Add logging to the bwdc when initializing it's lowdb storage service so any failures, issues, warning, etc. which may result in wiping of the data file (`data.json`) will get appropriately logged for further troubleshooting.

## Example
The resulting output, for example, if there's a syntax error (or other error) with the existing `data.json` file may look like this:

```bash
$ node bwdc.js login
Error creating lowdb storage adapter, "Malformed JSON in file: /Users/<user>/Library/Application Support/Bitwarden Directory Connector/data.json
Unexpected token h in JSON at position 303"; emptying data file.
```