### PR TITLE
Bump https-proxy-agent dep. to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "electron-updater": "4.2.0",
     "form-data": "2.3.2",
     "googleapis": "43.0.0",
-    "https-proxy-agent": "4.0.0",
+    "https-proxy-agent": "5.0.0",
     "inquirer": "6.2.0",
     "keytar": "4.13.0",
     "ldapjs": "git+https://git@github.com/kspearrin/node-ldapjs.git",


### PR DESCRIPTION
Hi,

As per requested by @cscharf - This PR is raised to bump a NodeJS dependency (`https-proxy-agent`) which solves an upstream bug in the [CLI repo](https://github.com/bitwarden/cli/issues/181). 

The bug in question prevents you from log in successfully when running CLI commands behind an HTTP proxy.
