### PR TITLE
dont catch api error and return false

### DIFF
--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -272,20 +272,18 @@ export class AzureDirectoryService extends BaseDirectoryService implements Direc
             return this.filterOutResult([userSetTypeExclude, setFilter[1]], user.email);
         }
 
-        try {
-            const memberGroups = await this.client.api(`/users/${user.externalId}/checkMemberGroups`).post({
-                groupIds: Array.from(setFilter[1]),
-            });
-            if (memberGroups.value.length > 0 && setFilter[0] === UserSetType.IncludeGroup) {
-                return false;
-            } else if (memberGroups.value.length > 0 && setFilter[0] === UserSetType.ExcludeGroup) {
-                return true;
-            } else if (memberGroups.value.length === 0 && setFilter[0] === UserSetType.IncludeGroup) {
-                return true;
-            } else if (memberGroups.value.length === 0 && setFilter[0] === UserSetType.ExcludeGroup) {
-                return false;
-            }
-        } catch { }
+        const memberGroups = await this.client.api(`/users/${user.externalId}/checkMemberGroups`).post({
+            groupIds: Array.from(setFilter[1]),
+        });
+        if (memberGroups.value.length > 0 && setFilter[0] === UserSetType.IncludeGroup) {
+            return false;
+        } else if (memberGroups.value.length > 0 && setFilter[0] === UserSetType.ExcludeGroup) {
+            return true;
+        } else if (memberGroups.value.length === 0 && setFilter[0] === UserSetType.IncludeGroup) {
+            return true;
+        } else if (memberGroups.value.length === 0 && setFilter[0] === UserSetType.ExcludeGroup) {
+            return false;
+        }
 
         return false;
     }


### PR DESCRIPTION
Customer was reporting that graph API calls were failing, which were being caught here and causing the user to not be filtered out of the synced result set. This allows the API call failure to propagate out further and return an error to the end user.