### PR TITLE
Fix filteringForUnsupportedUsers and extend email validation to handle emails up to 256 char

### DIFF
--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -104,7 +104,7 @@ export class SyncService {
     }
 
     private filterUnsupportedUsers(users: UserEntry[]): UserEntry[] {
-        return users == null ? null : users.filter(u => u.email?.length <= 50);
+        return users == null ? null : users.filter(u => u.email?.length <= 256);
     }
 
     private flattenUsersToGroups(levelGroups: GroupEntry[], allGroups: GroupEntry[]): Set<string> {

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -104,7 +104,7 @@ export class SyncService {
     }
 
     private filterUnsupportedUsers(users: UserEntry[]): UserEntry[] {
-        return users == null ? null : users.filter(u => u.email == null || u.email.length <= 50);
+        return users == null ? null : users.filter(u => u.email?.length <= 50);
     }
 
     private flattenUsersToGroups(levelGroups: GroupEntry[], allGroups: GroupEntry[]): Set<string> {


### PR DESCRIPTION
While working on bitwarden/server#1101 I found another place where an email's length is checked.

I encountered a faulty behaviour though, while checking the method [filterUnsupportedUsers in syncService.ts](https://github.com/bitwarden/directory-connector/blob/61c6ba81894fb6162cd51d26eb542fb616cf7a29/src/services/sync.service.ts#L106) 

Also check [jsFiddle](https://jsfiddle.net/1t89mou6/37/) for test cases

Finally, I extended the filter to handle emails with up to 256 chars