### PR TITLE
Fix AD sync not overwriting removed users

### DIFF
--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -57,7 +57,8 @@ export class SyncService {
                 this.flattenUsersToGroups(groups, groups);
             }
 
-            if (test || ((groups == null || groups.length === 0) && (users == null || users.length === 0))) {
+            if (test || (!syncConfig.overwriteExisting &&
+                        (groups == null || groups.length === 0) && (users == null || users.length === 0))) {
                 if (!test) {
                     await this.saveSyncTimes(syncConfig, now);
                 }


### PR DESCRIPTION
## Objective

Fix a bug that prevented AD users from being removed from their Bitwarden organization.

The steps to reproduce the bug are:

1. User is not in Bitwarden
2. User is created in AD (not Azure AD)
3. User is added to the AD Group, "APP_Bitwarden_TEST"
4. BWDC (Electron app) is configured to sync with a User filter of `memberof=cn=APP_Bitwarden_TEST` and with `overwriteExisting=true`.
5. BWDC syncs, finds the new user, sends a user invitation
6. User creates account, accepts invite, and admin confirms
8. User is removed from AD Group, "APP_Bitwarden_TEST"
9. Test BWDC sync - the filter should not pick up ANY users, disabled users, deleted users or groups. If any of these are present then this issue will not occur.
10. BWDC syncs - says that it syncs 0 users and 0 groups. The user is NOT removed from the organization as expected.

## Code changes

`SyncService` checks whether any sync data is returned from AD. If 0 users and 0 groups are returned (including deleted and disabled users), then it bails out without sending data back to the server. However, if `overwriteExisting` is enabled, then even an empty sync should be sent to the server so that it can remove users.