### PR TITLE
Resolve ExpressionChangedAfterItHasBeenCheckedError

### DIFF
--- a/src/app/tabs/dashboard.component.html
+++ b/src/app/tabs/dashboard.component.html
@@ -14,21 +14,25 @@
             <strong *ngIf="syncRunning" class="text-success">{{'running' | i18n}}</strong>
             <strong *ngIf="!syncRunning" class="text-danger">{{'stopped' | i18n}}</strong>
         </p>
-        <button #startBtn (click)="start()" [appApiAction]="startPromise" class="btn btn-primary"
-            [disabled]="startBtn.loading">
-            <i class="fa fa-play fa-fw" [hidden]="startBtn.loading"></i>
-            <i class="fa fa-spinner fa-fw fa-spin" [hidden]="!startBtn.loading"></i>
-            {{'startSync' | i18n}}
-        </button>
+        <form #startForm [appApiAction]="startPromise" class="d-inline">
+            <button #startBtn (click)="start()" class="btn btn-primary"
+                [disabled]="startForm.loading">
+                <i class="fa fa-play fa-fw" [hidden]="startForm.loading"></i>
+                <i class="fa fa-spinner fa-fw fa-spin" [hidden]="!startForm.loading"></i>
+                {{'startSync' | i18n}}
+            </button>
+        </form>
         <button (click)="stop()" class="btn btn-primary">
             <i class="fa fa-stop fa-fw"></i>
             {{'stopSync' | i18n}}
         </button>
-        <button #syncBtn (click)="sync()" [appApiAction]="syncPromise" class="btn btn-primary"
-            [disabled]="syncBtn.loading">
-            <i class="fa fa-refresh fa-fw" [ngClass]="{'fa-spin': syncBtn.loading}"></i>
-            {{'syncNow' | i18n}}
-        </button>
+        <form #syncForm [appApiAction]="syncPromise" class="d-inline">
+            <button #syncBtn (click)="sync()" class="btn btn-primary"
+                [disabled]="syncForm.loading">
+                <i class="fa fa-refresh fa-fw" [ngClass]="{'fa-spin': syncForm.loading}"></i>
+                {{'syncNow' | i18n}}
+            </button>
+        </form>
     </div>
 </div>
 <div class="card">

--- a/src/app/tabs/dashboard.component.html
+++ b/src/app/tabs/dashboard.component.html
@@ -15,7 +15,7 @@
             <strong *ngIf="!syncRunning" class="text-danger">{{'stopped' | i18n}}</strong>
         </p>
         <form #startForm [appApiAction]="startPromise" class="d-inline">
-            <button #startBtn (click)="start()" class="btn btn-primary"
+            <button (click)="start()" class="btn btn-primary"
                 [disabled]="startForm.loading">
                 <i class="fa fa-play fa-fw" [hidden]="startForm.loading"></i>
                 <i class="fa fa-spinner fa-fw fa-spin" [hidden]="!startForm.loading"></i>
@@ -27,7 +27,7 @@
             {{'stopSync' | i18n}}
         </button>
         <form #syncForm [appApiAction]="syncPromise" class="d-inline">
-            <button #syncBtn (click)="sync()" class="btn btn-primary"
+            <button (click)="sync()" class="btn btn-primary"
                 [disabled]="syncForm.loading">
                 <i class="fa fa-refresh fa-fw" [ngClass]="{'fa-spin': syncForm.loading}"></i>
                 {{'syncNow' | i18n}}
@@ -39,17 +39,19 @@
     <h3 class="card-header">{{'testing' | i18n}}</h3>
     <div class="card-body">
         <p>{{'testingDesc' | i18n}}</p>
-        <button #simBtn (click)="simulate()" [appApiAction]="simPromise" class="btn btn-primary"
-            [disabled]="simBtn.loading">
-            <i class="fa fa-spinner fa-fw fa-spin" [hidden]="!simBtn.loading"></i>
-            <i class="fa fa-bug fa-fw" [hidden]="simBtn.loading"></i>
-            {{'testNow' | i18n}}
-        </button>
+        <form #simForm [appApiAction]="simPromise" class="d-inline">
+            <button (click)="simulate()" class="btn btn-primary"
+                [disabled]="simForm.loading">
+                <i class="fa fa-spinner fa-fw fa-spin" [hidden]="!simForm.loading"></i>
+                <i class="fa fa-bug fa-fw" [hidden]="simForm.loading"></i>
+                {{'testNow' | i18n}}
+            </button>
+        </form>
         <div class="form-check mt-2">
             <input class="form-check-input" type="checkbox" id="simSinceLast" [(ngModel)]="simSinceLast">
             <label class="form-check-label" for="simSinceLast">{{'testLastSync' | i18n}}</label>
         </div>
-        <ng-container *ngIf="!simBtn.loading && (simUsers || simGroups)">
+        <ng-container *ngIf="!simForm.loading && (simUsers || simGroups)">
             <hr />
             <div class="row">
                 <div class="col-lg">


### PR DESCRIPTION
## Objective
When clicking the start or sync buttons angular casts a `ExpressionChangedAfterItHasBeenCheckedError` error. This seems to be caused by the elements referring to themselves using the `appApiAction` directive. By wrapping the buttons in forms and attaching the event to the forms we avoid this error.