### PR TITLE
Add node version to requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We provide detailed documentation and examples for using the Directory Connector
 
 **Requirements**
 
-- [Node.js](https://nodejs.org) v14.17 or greater
+- [Node.js](https://nodejs.org) v14
 - Windows users: To compile the native node modules used in the app you will need the Visual C++ toolset, available through the standard Visual Studio installer (recommended) or by installing [`windows-build-tools`](https://github.com/felixrieseberg/windows-build-tools) through `npm`. See more at [Compiling native Addon modules](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules).
 
 **Run the app**

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We provide detailed documentation and examples for using the Directory Connector
 
 **Requirements**
 
-- [Node.js](https://nodejs.org/)
+- [Node.js](https://nodejs.org) v14.17 or greater
 - Windows users: To compile the native node modules used in the app you will need the Visual C++ toolset, available through the standard Visual Studio installer (recommended) or by installing [`windows-build-tools`](https://github.com/felixrieseberg/windows-build-tools) through `npm`. See more at [Compiling native Addon modules](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules).
 
 **Run the app**


### PR DESCRIPTION
With @Hinton bumping node to 14 recently, I've adjusted the README to show the need for Node 14.17 (LTS)