### PR TITLE
OneLogin uses Roles instead of Groups

### DIFF
--- a/src/app/tabs/settings.component.html
+++ b/src/app/tabs/settings.component.html
@@ -345,12 +345,14 @@
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="syncGroups" [(ngModel)]="sync.groups"
                             name="SyncGroups">
-                        <label class="form-check-label" for="syncGroups">{{'syncGroups' | i18n}}</label>
+                        <label class="form-check-label" for="syncGroups">{{(directory !== directoryType.OneLogin ?
+                            'syncGroups' : 'syncGroupsOneLogin') | i18n}}</label>
                     </div>
                 </div>
                 <div [hidden]="!sync.groups">
                     <div class="form-group">
-                        <label for="groupFilter">{{'groupFilter' | i18n}}</label>
+                        <label for="groupFilter">{{(directory !== directoryType.OneLogin ? 'groupFilter' :
+                            'groupFilterOneLogin') | i18n}}</label>
                         <textarea class="form-control" id="groupFilter" name="GroupFilter"
                             [(ngModel)]="sync.groupFilter"></textarea>
                         <small class="text-muted form-text" *ngIf="directory === directoryType.Ldap">{{'ex' | i18n}}

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -402,6 +402,12 @@
     "groupFilter": {
         "message": "Group Filter"
     },
+    "syncGroupsOneLogin": {
+        "message": "Sync roles"
+    },
+    "groupFilterOneLogin": {
+        "message": "Role Filter"
+    },
     "groupObjectClass": {
         "message": "Group Object Class"
     },
@@ -602,6 +608,9 @@
                 "example": "server"
             }
         }
+    },
+    "largeImport": {
+        "message": "More than 2000 users or groups are expected to sync."
     },
     "overwriteExisting": {
         "message": "Overwrite existing organization users based on current sync settings."


### PR DESCRIPTION
# Overview

Closes https://app.asana.com/0/1153292148278596/1199515611430068/f.

One Login uses the Role concept instead of Groups for filtering bitwarden groups. This PR alters the language of our filters to Role rather than group

# Screenshot
<img width="1648" alt="image" src="https://user-images.githubusercontent.com/18214891/118137610-047d8500-b3cb-11eb-90b6-f4548d0a18cc.png">#117 