### PR TITLE
Add option to bypass large import limit of 2000 users

### DIFF
--- a/src/app/tabs/settings.component.html
+++ b/src/app/tabs/settings.component.html
@@ -283,8 +283,8 @@
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" id="useEmailPrefixSuffix"
                                 [(ngModel)]="sync.useEmailPrefixSuffix" name="UseEmailPrefixSuffix">
-                            <label class="form-check-label" for="useEmailPrefixSuffix">{{'useEmailPrefixSuffix' |
-                                i18n}}</label>
+                            <label class="form-check-label"
+                                for="useEmailPrefixSuffix">{{'useEmailPrefixSuffix' | i18n}}</label>
                         </div>
                     </div>
                     <div [hidden]="!sync.useEmailPrefixSuffix">

--- a/src/app/tabs/settings.component.html
+++ b/src/app/tabs/settings.component.html
@@ -37,8 +37,7 @@
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" id="pagedSearch"
                                 [(ngModel)]="ldap.pagedSearch" name="PagedSearch">
-                            <label class="form-check-label"
-                                for="pagedSearch">{{'ldapPagedResults' | i18n}}</label>
+                            <label class="form-check-label" for="pagedSearch">{{'ldapPagedResults' | i18n}}</label>
                         </div>
                     </div>
                     <div class="form-group">
@@ -99,8 +98,8 @@
                             <div class="form-check">
                                 <input class="form-check-input" type="checkbox" id="certDoNotVerify"
                                     [(ngModel)]="ldap.sslAllowUnauthorized" name="CertDoNoVerify">
-                                <label class="form-check-label"
-                                    for="certDoNotVerify">{{'ldapCertDoNotVerify' | i18n}}</label>
+                                <label class="form-check-label" for="certDoNotVerify">{{'ldapCertDoNotVerify' |
+                                    i18n}}</label>
                             </div>
                         </div>
                     </div>
@@ -250,6 +249,13 @@
                         <label class="form-check-label" for="overwriteExisting">{{'overwriteExisting' | i18n}}</label>
                     </div>
                 </div>
+                <div class="form-group">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="largeImport" [(ngModel)]="sync.largeImport"
+                            name="LargeImport">
+                        <label class="form-check-label" for="largeImport">{{'largeImport' | i18n}}</label>
+                    </div>
+                </div>
                 <div [hidden]="directory != directoryType.Ldap">
                     <div [hidden]="ldap.ad">
                         <div class="form-group">
@@ -277,8 +283,8 @@
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" id="useEmailPrefixSuffix"
                                 [(ngModel)]="sync.useEmailPrefixSuffix" name="UseEmailPrefixSuffix">
-                            <label class="form-check-label"
-                                for="useEmailPrefixSuffix">{{'useEmailPrefixSuffix' | i18n}}</label>
+                            <label class="form-check-label" for="useEmailPrefixSuffix">{{'useEmailPrefixSuffix' |
+                                i18n}}</label>
                         </div>
                     </div>
                     <div [hidden]="!sync.useEmailPrefixSuffix">

--- a/src/commands/sync.command.ts
+++ b/src/commands/sync.command.ts
@@ -1,5 +1,3 @@
-import * as program from 'commander';
-
 import { I18nService } from 'jslib/abstractions/i18n.service';
 
 import { SyncService } from '../services/sync.service';

--- a/src/models/syncConfiguration.ts
+++ b/src/models/syncConfiguration.ts
@@ -6,6 +6,7 @@ export class SyncConfiguration {
     groupFilter: string;
     removeDisabled = false;
     overwriteExisting = false;
+    largeImport = false;
     // Ldap properties
     groupObjectClass: string;
     userObjectClass: string;

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -75,14 +75,20 @@ export class SyncService {
                 throw new Error('Organization not set.');
             }
 
+            // TODO: Remove hashLegacy once we're sure clients have had time to sync new hashes
+            let hashLegacy: string = null;
+            const hashBuffLegacy = await this.cryptoFunctionService.hash(this.apiService.apiBaseUrl + reqJson, 'sha256');
+            if (hashBuffLegacy != null) {
+                hashLegacy = Utils.fromBufferToB64(hashBuffLegacy);
+            }
             let hash: string = null;
-            const hashBuf = await this.cryptoFunctionService.hash(this.apiService.apiBaseUrl + orgId + reqJson, 'sha256');
-            if (hashBuf != null) {
-                hash = Utils.fromBufferToB64(hashBuf);
+            const hashBuff = await this.cryptoFunctionService.hash(this.apiService.apiBaseUrl + orgId + reqJson, 'sha256');
+            if (hashBuff != null) {
+                hash = Utils.fromBufferToB64(hashBuff);
             }
             const lastHash = await this.configurationService.getLastSyncHash();
 
-            if (lastHash == null || hash !== lastHash) {
+            if (lastHash == null || hash !== lastHash || hashLegacy !== lastHash) {
                 await this.apiService.postImportDirectory(orgId, req);
                 await this.configurationService.saveLastSyncHash(hash);
             } else {

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -88,7 +88,7 @@ export class SyncService {
             }
             const lastHash = await this.configurationService.getLastSyncHash();
 
-            if (lastHash == null || hash !== lastHash || hashLegacy !== lastHash) {
+            if (lastHash == null || (hash !== lastHash && hashLegacy !== lastHash)) {
                 await this.apiService.postImportDirectory(orgId, req);
                 await this.configurationService.saveLastSyncHash(hash);
             } else {

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -67,22 +67,22 @@ export class SyncService {
                 return [groups, users];
             }
 
-            const req = this.buildRequest(groups, users, syncConfig.removeDisabled, syncConfig.overwriteExisting);
+            const req = this.buildRequest(groups, users, syncConfig.removeDisabled, syncConfig.overwriteExisting, syncConfig.largeImport);
             const reqJson = JSON.stringify(req);
 
+            const orgId = await this.configurationService.getOrganizationId();
+            if (orgId == null) {
+                throw new Error('Organization not set.');
+            }
+
             let hash: string = null;
-            const hashBuf = await this.cryptoFunctionService.hash(this.apiService.apiBaseUrl + reqJson, 'sha256');
+            const hashBuf = await this.cryptoFunctionService.hash(this.apiService.apiBaseUrl + orgId + reqJson, 'sha256');
             if (hashBuf != null) {
                 hash = Utils.fromBufferToB64(hashBuf);
             }
             const lastHash = await this.configurationService.getLastSyncHash();
 
             if (lastHash == null || hash !== lastHash) {
-                const orgId = await this.configurationService.getOrganizationId();
-                if (orgId == null) {
-                    throw new Error('Organization not set.');
-                }
-
                 await this.apiService.postImportDirectory(orgId, req);
                 await this.configurationService.saveLastSyncHash(hash);
             } else {
@@ -140,9 +140,10 @@ export class SyncService {
     }
 
     private buildRequest(groups: GroupEntry[], users: UserEntry[], removeDisabled: boolean,
-        overwriteExisting: boolean): ImportDirectoryRequest {
+        overwriteExisting: boolean, largeImport: boolean): ImportDirectoryRequest {
         const model = new ImportDirectoryRequest();
         model.overwriteExisting = overwriteExisting;
+        model.largeImport = largeImport;
 
         if (groups != null) {
             for (const g of groups) {


### PR DESCRIPTION
# Overview

Related to bitwarden/server#1311. Allows import of large numbers of users and groups. Also add orgId to last sync hash.

# Files Changed
* **settings.component.html**: Add `largeImport` checkbox button. Formatting changes.
* **sync.command.ts**: remove unneccessary using
* **syncConfiguration.ts**: Add largeImport
* **sync.service.ts**: specify largeImport. Add orgId to last sync hash. This resolves issue where changing the organization synced to would not update until directory changes exist.