### PR TITLE
constraining release to the rc branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,15 @@ jobs:
       tag_version: ${{ steps.create_tags.outputs.tag_version }}
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
+      - name: Branch check
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]]; then
+            echo "==================================="
+            echo "[!] Can only release from rc branch"
+            echo "==================================="
+            exit 1
+          fi
+
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 


### PR DESCRIPTION
## Summary

In the DevOps retro, we identified that the release workflows of the clients should be programmatically constrained to the `rc` branch to protect from human error on release