### PR TITLE
[Feature] Option to remove group prefix if Azure AD is used.

### DIFF
--- a/src/app/tabs/settings.component.html
+++ b/src/app/tabs/settings.component.html
@@ -360,6 +360,9 @@
                         <small class="text-muted form-text" *ngIf="directory === directoryType.GSuite">{{'ex' | i18n}}
                             include:Sales,IT</small>
                     </div>
+                    <label for="groupPrefix" [hidden]="directory != directoryType.AzureActiveDirectory">{{'groupPrefix' | i18n}}</label>
+                    <input type="text" class="form-control" id="groupPrefix" name="GroupPrefix"
+                           [(ngModel)]="sync.groupPrefix" [hidden]="directory != directoryType.AzureActiveDirectory">
                     <div class="form-group" [hidden]="directory != directoryType.Ldap">
                         <label for="groupPath">{{'groupPath' | i18n}}</label>
                         <input type="text" class="form-control" id="groupPath" name="GroupPath"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -420,6 +420,9 @@
     "groupFilter": {
         "message": "Group Filter"
     },
+    "groupPrefix": {
+        "message": "Remove group prefix"
+    },
     "syncGroupsOneLogin": {
         "message": "Sync roles"
     },

--- a/src/models/syncConfiguration.ts
+++ b/src/models/syncConfiguration.ts
@@ -1,6 +1,7 @@
 export class SyncConfiguration {
     users = false;
     groups = false;
+    groupPrefix: string;
     interval = 5;
     userFilter: string;
     groupFilter: string;

--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -355,7 +355,9 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
         const entry = new GroupEntry();
         entry.referenceId = group.id;
         entry.externalId = group.id;
-        entry.name = group.displayName;
+        entry.name = this.syncConfig.groupPrefix != null ?
+            group.displayName.replace(new RegExp(`^${this.syncConfig.groupPrefix}`), '') :
+            group.displayName;
 
         const memReq = this.client.api('/groups/' + group.id + '/members');
         let memRes = await memReq.get();


### PR DESCRIPTION
Assuming we have a group naming convention like `_Bitwarden_Project_Customer` it might
be nice to remove the prefix `_Bitwarden_` so that the created group name will
be `Project_Customer`. This comes in handy in a combination with longer group names indicating the nested
structure of collections.