### PR TITLE
Improve okta group performance

### DIFF
--- a/src/services/okta-directory.service.ts
+++ b/src/services/okta-directory.service.ts
@@ -118,17 +118,13 @@ export class OktaDirectoryService extends BaseDirectoryService implements IDirec
         const oktaFilter = this.buildOktaFilter(this.syncConfig.groupFilter, force, lastSync);
 
         this.logService.info('Querying groups.');
-        console.time('initial API')
         await this.apiGetMany('groups?filter=' + this.encodeUrlParameter(oktaFilter)).then(async (groups: any[]) => {
-            console.timeEnd('initial API');
-            console.time('get groups specifics');
             for (const group of groups.filter(g => !this.filterOutResult(setFilter, g.profile.name))) {
                 const entry = await this.buildGroup(group);
                 if (entry != null) {
                     entries.push(entry);
                 }
             }
-            console.timeEnd('get groups specifics');
         });
         return entries;
     }


### PR DESCRIPTION
# Overview

Filter excluded/included groups as early as possible to avoid using up API calls and long waits.

We got some complaints concerning Okta-sync speed. Luckily the users have filters set, so we can improve things by filtering out groups earlier.

I also refactored the wait some to apply to `buildGroup` method. This saves us one wait, not a huge deal, but every bit helps 😃 