### PR TITLE
Refresh token with api key

### DIFF
--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -21,7 +21,6 @@ import { SyncService } from '../../services/sync.service';
 import { BroadcasterService } from 'jslib-angular/services/broadcaster.service';
 import { ValidationService } from 'jslib-angular/services/validation.service';
 
-import { ApiService } from 'jslib-common/services/api.service';
 import { ApiKeyService } from 'jslib-common/services/apiKey.service';
 import { AppIdService } from 'jslib-common/services/appId.service';
 import { ConstantsService } from 'jslib-common/services/constants.service';
@@ -55,6 +54,7 @@ import { StorageService as StorageServiceAbstraction } from 'jslib-common/abstra
 import { TokenService as TokenServiceAbstraction } from 'jslib-common/abstractions/token.service';
 import { UserService as UserServiceAbstraction } from 'jslib-common/abstractions/user.service';
 
+import { ApiService, refreshToken } from '../../services/api.service';
 import { AuthService } from '../../services/auth.service';
 
 const logService = new ElectronLogService();
@@ -70,7 +70,7 @@ const cryptoService = new CryptoService(storageService, secureStorageService, cr
     platformUtilsService, logService);
 const appIdService = new AppIdService(storageService);
 const tokenService = new TokenService(storageService);
-const apiService = new ApiService(tokenService, platformUtilsService,
+const apiService = new ApiService(tokenService, platformUtilsService, refreshTokenCallback,
     async (expired: boolean) => messagingService.send('logout', { expired: expired }));
 const environmentService = new EnvironmentService(apiService, storageService, null);
 const userService = new UserService(tokenService, storageService);
@@ -85,6 +85,10 @@ const passwordGenerationService = new PasswordGenerationService(cryptoService, s
 const policyService = new PolicyService(userService, storageService);
 
 containerService.attachToWindow(window);
+
+function refreshTokenCallback(): Promise<any> {
+    return refreshToken(apiKeyService, authService);
+}
 
 export function initFactory(): Function {
     return async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,7 @@ export class Main {
             this.messagingMain.onMessage(message);
         });
 
-        this.keytarStorageListener = new KeytarStorageListener('Bitwarden Directory Connector');
+        this.keytarStorageListener = new KeytarStorageListener('Bitwarden Directory Connector', null);
     }
 
     bootstrap() {

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -2,6 +2,7 @@ import { ApiKeyService } from 'jslib-common/abstractions/apiKey.service';
 import { AuthService } from 'jslib-common/abstractions/auth.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
 import { TokenService } from 'jslib-common/abstractions/token.service';
+
 import { ApiService as ApiServiceBase } from 'jslib-common/services/api.service';
 
 export async function refreshToken(apiKeyService: ApiKeyService, authService: AuthService) {

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -1,0 +1,29 @@
+import { ApiKeyService } from 'jslib-common/abstractions/apiKey.service';
+import { AuthService } from 'jslib-common/abstractions/auth.service';
+import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
+import { TokenService } from 'jslib-common/abstractions/token.service';
+import { ApiService as ApiServiceBase } from 'jslib-common/services/api.service';
+
+export async function refreshToken(apiKeyService: ApiKeyService, authService: AuthService) {
+    try {
+        const clientId = await apiKeyService.getClientId();
+        const clientSecret = await apiKeyService.getClientSecret();
+        if (clientId != null && clientSecret != null) {
+            await authService.logInApiKey(clientId, clientSecret);
+        }
+    } catch (e) {
+        return Promise.reject(e);
+    }
+}
+
+export class ApiService extends ApiServiceBase {
+    constructor(tokenService: TokenService, platformUtilsService: PlatformUtilsService,
+        private refreshTokenCallback: () => Promise<void>, logoutCallback: (expired: boolean) => Promise<void>,
+        customUserAgent: string = null) {
+        super(tokenService, platformUtilsService, logoutCallback, customUserAgent);
+    }
+
+    doRefreshToken(): Promise<void> {
+        return this.refreshTokenCallback();
+    }
+}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -36,6 +36,11 @@ export class AuthService extends AuthServiceBase {
         return await super.logInApiKey(clientId, clientSecret);
     }
 
+    async logOut(callback: Function) {
+        this.apiKeyService.clear();
+        super.logOut(callback);
+    }
+
     private async organizationLogInHelper(clientId: string, clientSecret: string) {
         const appId = await this.appIdService.getAppId();
         const deviceRequest = new DeviceRequest(appId, this.platformUtilsService);
@@ -49,7 +54,7 @@ export class AuthService extends AuthServiceBase {
         const tokenResponse = response as IdentityTokenResponse;
         result.resetMasterPassword = tokenResponse.resetMasterPassword;
         await this.tokenService.setToken(tokenResponse.accessToken);
-        await this.apiKeyService.setInformation(clientId);
+        await this.apiKeyService.setInformation(clientId, clientSecret);
 
         return result;
     }

--- a/src/services/keytarSecureStorage.service.ts
+++ b/src/services/keytarSecureStorage.service.ts
@@ -15,6 +15,10 @@ export class KeytarSecureStorageService implements StorageService {
         });
     }
 
+    async has(key: string): Promise<boolean> {
+        return (await this.get(key)) != null;
+    }
+
     save(key: string, obj: any): Promise<any> {
         return setPassword(this.serviceName, key, JSON.stringify(obj));
     }

--- a/src/services/nodeApi.service.ts
+++ b/src/services/nodeApi.service.ts
@@ -1,10 +1,12 @@
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
 import { TokenService } from 'jslib-common/abstractions/token.service';
+
 import { NodeApiService as NodeApiServiceBase } from 'jslib-node/services/nodeApi.service';
 
 export class NodeApiService extends NodeApiServiceBase {
     constructor(tokenService: TokenService, platformUtilsService: PlatformUtilsService,
-        private refreshTokenCallback: () => Promise<void>, logoutCallback: (expired: boolean) => Promise<void>, customUserAgent: string = null) {
+        private refreshTokenCallback: () => Promise<void>, logoutCallback: (expired: boolean) => Promise<void>,
+        customUserAgent: string = null) {
         super(tokenService, platformUtilsService, logoutCallback, customUserAgent);
     }
 

--- a/src/services/nodeApi.service.ts
+++ b/src/services/nodeApi.service.ts
@@ -1,0 +1,14 @@
+import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
+import { TokenService } from 'jslib-common/abstractions/token.service';
+import { NodeApiService as NodeApiServiceBase } from 'jslib-node/services/nodeApi.service';
+
+export class NodeApiService extends NodeApiServiceBase {
+    constructor(tokenService: TokenService, platformUtilsService: PlatformUtilsService,
+        private refreshTokenCallback: () => Promise<void>, logoutCallback: (expired: boolean) => Promise<void>, customUserAgent: string = null) {
+        super(tokenService, platformUtilsService, logoutCallback, customUserAgent);
+    }
+
+    doRefreshToken(): Promise<void> {
+        return this.refreshTokenCallback();
+    }
+}


### PR DESCRIPTION
# Overview

Linked to bitwarden/jslib#414

bitwarden/jslib#382 and bitwarden/directory-connector#121 switched authentication to organization API key flow. However, this authentication does not include refresh tokens.

This work extends `ApiService` to override the token refresh flow with the api key authentication flow.

# Files changed
* **services.module.ts/bwdc.ts**: Update services to new `ApiService`. `refreshToken` is a little wonky. A method is needed due to a circular dependency on `apiKeyService` and `authService` to perform the refresh. I'm exporting the method because I wanted a single code source, but `ApiService` is already split higher upstream, requiring both `ApiService` and `NodeApiService` to be extended. The Compromise is to define the method in one of the `api.service.ts` files and export it while supplying the appropriate service dependencies.
* **api.service.ts**: New electron api service, overriding `doRefreshToken`
* **auth.service.ts**: Clear out client credentials when logging out.
* **nodeApi.service.ts**: New CLI apie service, overriding `doRefreshToken`