### PR TITLE
Fix Azure client errors not displaying properly

### DIFF
--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -386,7 +386,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
             authProvider: done => {
                 if (this.dirConfig.applicationId == null || this.dirConfig.key == null ||
                     this.dirConfig.tenant == null) {
-                    done(this.i18nService.t('dirConfigIncomplete'), null);
+                    done(new Error(this.i18nService.t('dirConfigIncomplete')), null);
                     return;
                 }
 
@@ -421,9 +421,14 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
                             this.setAccessTokenExpiration(d.access_token, d.expires_in);
                             done(null, d.access_token);
                         } else if (d.error != null && d.error_description != null) {
-                            done(d.error + ' (' + res.statusCode + '): ' + d.error_description, null);
+                            const shortError = d.error_description?.split('\n', 1)[0];
+                            const err = new Error(d.error + ' (' + res.statusCode + '): ' + shortError);
+                            // tslint: disable-next-line
+                            console.error(d.error_description);
+                            done(err, null);
                         } else {
-                            done('Unknown error (' + res.statusCode + ').', null);
+                            const err = new Error('Unknown error (' + res.statusCode + ').')
+                            done(err, null);
                         }
                     });
                 }).on('error', err => {


### PR DESCRIPTION
## Objective

Fix this behaviour, as requested by the good folks over in customer success:

>When configuring BWDC to use Azure Active Directory sync, and an invalid Application ID or Secret Key for the Azure AD auth is provided, BWDC displays an "unknown error has occurred" error card and does not log any network requests or errors on the console. BWDC should display "invalid AppID or secret key" instead.

## Code changes

In `azureDirectoryService.init()`, we define a callback which is responsible for authenticating and getting the access token. After its work is completed, it calls the `done` function with either an error or the access token.

It looked like we were doing this already, but we were getting stack traces rather than nice error messages, and that was changed to a generic error message by `appApiAction`. It turns out that `done` should receive an `Error` object, not just a string containing the error message. After changing error strings to `Error` objects, they display as expected.

Azure provides fairly verbose messages, so for better UX I have only displayed the first line in the toast, and printed the rest to the console. This code only applies to Azure authentication errors so I felt I could be reasonably specific.

Here's an example of how it looks:

![Screen Shot 2021-08-18 at 4 28 45 pm](https://user-images.githubusercontent.com/31796059/129848836-8699e42a-5eeb-4bad-8771-ffc423ae8958.png)

For comparison, here's how it looks if we don't do this (keeping in mind you have about 3 seconds to parse this before it disappears):

![Screen Shot 2021-08-18 at 4 05 35 pm](https://user-images.githubusercontent.com/31796059/129848864-9ab671cb-7bdd-4634-b5f4-32959a444b06.png)