### PR TITLE
Bump patch version to denote no features released

### DIFF
--- a/src-cli/package.json
+++ b/src-cli/package.json
@@ -2,7 +2,7 @@
   "name": "bitwarden-directory-connector",
   "productName": "Bitwarden Directory Connector",
   "description": "Sync your user directory to your Bitwarden organization.",
-  "version": "2.10.0",
+  "version": "2.9.4",
   "author": "Bitwarden Inc. <hello@bitwarden.com> (https://bitwarden.com)",
   "homepage": "https://bitwarden.com",
   "license": "GPL-3.0",

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
   "name": "bitwarden-directory-connector",
   "productName": "Bitwarden Directory Connector",
   "description": "Sync your user directory to your Bitwarden organization.",
-  "version": "2.10.0",
+  "version": "2.9.4",
   "author": "Bitwarden Inc. <hello@bitwarden.com> (https://bitwarden.com)",
   "homepage": "https://bitwarden.com",
   "license": "GPL-3.0",


### PR DESCRIPTION
2.10.0 is unreleased and should have been merely a patch bump from 2.9.3 since no features were added.

> Note: will be cherry picked to `rc`