### PR TITLE
Ignore duplicate users with same externalId

### DIFF
--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -144,7 +144,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
                         continue;
                     }
                     const entry = this.buildUser(user);
-                    if (!entry.disabled && !entry.deleted) {
+                    if (!entry.deleted) {
                         continue;
                     }
                     if (await this.filterOutUserResult(setFilter, entry, false)) {

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -117,16 +117,16 @@ export class SyncService {
         const processedUsers = new Map<string, string>();
         const duplicateEmails = new Array<string>();
 
-        // UserEntrys with the same email and externalId are removed but otherwise ignored
-        // UserEntrys with the same email but different externalIds will throw an error
+        // UserEntrys with the same email are ignored if their properties are the same
+        // UserEntrys with the same email but different properties will throw an error
         users.forEach(u => {
             if (processedUsers.has(u.email)) {
-                if (u.externalId == null || processedUsers.get(u.email) != u.externalId) {
+                if (processedUsers.get(u.email) != JSON.stringify(u)) {
                     duplicateEmails.push(u.email);
                 }
             } else {
                 uniqueUsers.push(u);
-                processedUsers.set(u.email, u.externalId);
+                processedUsers.set(u.email, JSON.stringify(u));
             }
         });
 

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -121,7 +121,7 @@ export class SyncService {
         // UserEntrys with the same email but different externalIds will throw an error
         users.forEach(u => {
             if (processedUsers.has(u.email)) {
-                if (processedUsers.get(u.email) != u.externalId) {
+                if (processedUsers.get(u.email) != u.externalId || u.externalId == null) {
                     duplicateEmails.push(u.email);
                 }
             } else {

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -121,7 +121,7 @@ export class SyncService {
         // UserEntrys with the same email but different externalIds will throw an error
         users.forEach(u => {
             if (processedUsers.has(u.email)) {
-                if (processedUsers.get(u.email) != u.externalId || u.externalId == null) {
+                if (u.externalId == null || processedUsers.get(u.email) != u.externalId) {
                     duplicateEmails.push(u.email);
                 }
             } else {


### PR DESCRIPTION
## Objective

We made some changes [here](https://github.com/bitwarden/directory-connector/pull/136) to throw an error if the directory service contains 2 or more users with the same email address. This is because we don't support duplicate email addresses in Bitwarden.

Some users have reported false positives, where the error was being thrown even though they didn't think that they had more than 1 user with the same email address.

I was able to reproduce this by simply disabling a user in Azure AD. This caused the disabled user to be returned by both the `getCurrentUsers` and the `getDeletedUsers` methods, which then caused the duplicate entry.

## Code changes

* `sync.service` - only throw an error if multiple `userEntry`s have the same email address but _different_ `externalId`s. `externalId`s should be unique to each user, so if the email address and `externalId` are identical, it's probably the same user and we can safely remove the duplicates without throwing the error. This should reduce the incidence of false positives.
* `azure-directory.service` - change the boolean logic of `getDeletedUsers` so that disabled (but not deleted) users are excluded from this user set. This should remove the source of the duplicate to begin with. I wasn't 100% sure which set disabled users should go in, because they are neither "current" nor "deleted", but (a) I don't think it matters too much because both sets are concatenated at the end, so as long as there's no overlap, and (b) at a glance, I _think_ our LDAP and GSuite services work this way, so this seemed the most consistent.