### PR TITLE
CLI release job update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release_upload_url }}
-          asset_path: ./dist-cli/bwdc-windows-${{ env._PACKAGE_VERSION }}.zip
+          asset_path: ./dist-cli/bwdc-windows-${{ env._PACKAGE_VERSION }}.zip/bwdc-windows-${{ env._PACKAGE_VERSION }}.zip
           asset_name: bwdc-windows-${{ env._PACKAGE_VERSION }}.zip
           asset_content_type: application/zip
 
@@ -98,7 +98,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release_upload_url }}
-          asset_path: ./dist-cli/bwdc-macos-${{ env._PACKAGE_VERSION }}.zip
+          asset_path: ./dist-cli/bwdc-macos-${{ env._PACKAGE_VERSION }}.zip/bwdc-macos-${{ env._PACKAGE_VERSION }}.zip
           asset_name: bwdc-macos-${{ env._PACKAGE_VERSION }}.zip
           asset_content_type: application/zip
 
@@ -108,7 +108,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release_upload_url }}
-          asset_path: ./dist-cli/bwdc-linux-${{ env._PACKAGE_VERSION }}.zip
+          asset_path: ./dist-cli/bwdc-linux-${{ env._PACKAGE_VERSION }}.zip/bwdc-linux-${{ env._PACKAGE_VERSION }}.zip
           asset_name: bwdc-linux-${{ env._PACKAGE_VERSION }}.zip
           asset_content_type: application/zip
 
@@ -118,7 +118,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release_upload_url }}
-          asset_path: ./dist-cli/bwdc-windows-sha256-${{ env._PACKAGE_VERSION }}.txt
+          asset_path: ./dist-cli/bwdc-windows-sha256-${{ env._PACKAGE_VERSION }}.txt/bwdc-windows-sha256-${{ env._PACKAGE_VERSION }}.txt
           asset_name: bwdc-windows-sha256-${{ env._PACKAGE_VERSION }}.txt
           asset_content_type: text/plain
 
@@ -128,7 +128,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release_upload_url }}
-          asset_path: ./dist-cli/bwdc-macos-sha256-${{ env._PACKAGE_VERSION }}.txt
+          asset_path: ./dist-cli/bwdc-macos-sha256-${{ env._PACKAGE_VERSION }}.txt/bwdc-macos-sha256-${{ env._PACKAGE_VERSION }}.txt
           asset_name: bwdc-macos-sha256-${{ env._PACKAGE_VERSION }}.txt
           asset_content_type: text/plain
 
@@ -138,7 +138,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release_upload_url }}
-          asset_path: ./dist-cli/bwdc-linux-sha256-${{ env._PACKAGE_VERSION }}.txt
+          asset_path: ./dist-cli/bwdc-linux-sha256-${{ env._PACKAGE_VERSION }}.txt/bwdc-linux-sha256-${{ env._PACKAGE_VERSION }}.txt
           asset_name: bwdc-linux-sha256-${{ env._PACKAGE_VERSION }}.txt
           asset_content_type: text/plain
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,109 +70,63 @@ jobs:
     needs: setup
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
-      _WIN_PKG_FETCH_VERSION: 14.17.0
-      _WIN_PKG_VERSION: 3.1
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
-      - name: Setup Windows builder
-        run: |
-          choco install checksum --no-progress
-          choco install reshack --no-progress
-
-      - name: Set up Node
-        uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
+      - name: Download latest Windows zip artifact
+        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
         with:
-          node-version: '14.x'
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: rc
+          name: bwdc-windows-${{ env._PACKAGE_VERSION }}.zip
+          path: ./dist-cli
 
-      - name: Update NPM
-        run: |
-          npm install -g npm@7
-          npm install -g node-gyp
-          node-gyp install $(node -v)
+      - name: Download latest Mac zip artifact
+        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
+        with:
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: rc
+          name: bwdc-mac-${{ env._PACKAGE_VERSION }}.zip
+          path: ./dist-cli
 
-      - name: Get pkg-fetch
-        shell: pwsh
-        run: |
-          cd $HOME
-          $fetchedUrl = "https://github.com/vercel/pkg-fetch/releases/download/v$env:_WIN_PKG_VERSION/node-v$env:_WIN_PKG_FETCH_VERSION-win-x64"
+      - name: Download latest Linux zip artifact
+        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
+        with:
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: rc
+          name: bwdc-linux-${{ env._PACKAGE_VERSION }}.zip
+          path: ./dist-cli
 
-          New-Item -ItemType directory -Path ./.pkg-cache
-          New-Item -ItemType directory -Path ./.pkg-cache/v$env:_WIN_PKG_VERSION
-          Invoke-RestMethod -Uri $fetchedUrl -OutFile "./.pkg-cache/v$env:_WIN_PKG_VERSION/fetched-v$env:_WIN_PKG_FETCH_VERSION-win-x64"
+      - name: Download latest Windows checksum
+        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
+        with:
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: rc
+          name: bwdc-windows-sha256-${{ env._PACKAGE_VERSION }}.txt
+          path: ./dist-cli
 
-      - name: Keytar
-        shell: pwsh
-        run: |
-          $keytarVersion = (Get-Content -Raw -Path ./src/package.json | ConvertFrom-Json).dependencies.keytar
-          $nodeModVersion = node -e "console.log(process.config.variables.node_module_version)"
-          $keytarTar = "keytar-v${keytarVersion}-node-v${nodeModVersion}-{0}-x64.tar"
-          $keytarTarGz = "${keytarTar}.gz"
-          $keytarUrl = "https://github.com/atom/node-keytar/releases/download/v${keytarVersion}/${keytarTarGz}"
+      - name: Download latest Mac checksum
+        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
+        with:
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: rc
+          name: bwdc-mac-sha256-${{ env._PACKAGE_VERSION }}.txt
+          path: ./dist-cli
 
-          New-Item -ItemType directory -Path ./keytar/macos | Out-Null
-          New-Item -ItemType directory -Path ./keytar/linux | Out-Null
-          New-Item -ItemType directory -Path ./keytar/windows | Out-Null
-
-          Invoke-RestMethod -Uri $($keytarUrl -f "darwin") -OutFile "./keytar/macos/$($keytarTarGz -f "darwin")"
-          Invoke-RestMethod -Uri $($keytarUrl -f "linux") -OutFile "./keytar/linux/$($keytarTarGz -f "linux")"
-          Invoke-RestMethod -Uri $($keytarUrl -f "win32") -OutFile "./keytar/windows/$($keytarTarGz -f "win32")"
-
-          7z e "./keytar/macos/$($keytarTarGz -f "darwin")" -o"./keytar/macos"
-          7z e "./keytar/linux/$($keytarTarGz -f "linux")" -o"./keytar/linux"
-          7z e "./keytar/windows/$($keytarTarGz -f "win32")" -o"./keytar/windows"
-
-          7z e "./keytar/macos/$($keytarTar -f "darwin")" -o"./keytar/macos"
-          7z e "./keytar/linux/$($keytarTar -f "linux")" -o"./keytar/linux"
-          7z e "./keytar/windows/$($keytarTar -f "win32")" -o"./keytar/windows"
-
-      - name: Setup Version Info
-        shell: pwsh
-        run: ./scripts/make-versioninfo.ps1
-
-      - name: Resource Hacker
-        shell: cmd
-        run: |
-          set PATH=%PATH%;C:\Program Files (x86)\Resource Hacker
-          set WIN_PKG=C:\Users\runneradmin\.pkg-cache\v%_WIN_PKG_VERSION%\fetched-v%_WIN_PKG_FETCH_VERSION%-win-x64
-          set WIN_PKG_BUILT=C:\Users\runneradmin\.pkg-cache\v%_WIN_PKG_VERSION%\built-v%_WIN_PKG_FETCH_VERSION%-win-x64
-
-          ResourceHacker -open %WIN_PKG% -save %WIN_PKG% -action delete -mask ICONGROUP,1,
-          ResourceHacker -open version-info.rc -save version-info.res -action compile
-          ResourceHacker -open %WIN_PKG% -save %WIN_PKG% -action addoverwrite -resource version-info.res
-
-      - name: Install
-        run: npm install
-
-      - name: Package CLI
-        run: npm run dist:cli
-
-      - name: Zip
-        shell: cmd
-        run: |
-          7z a ./dist-cli/bwdc-windows-%_PACKAGE_VERSION%.zip ./dist-cli/windows/bwdc.exe ./keytar/windows/keytar.node
-          7z a ./dist-cli/bwdc-macos-%_PACKAGE_VERSION%.zip ./dist-cli/macos/bwdc ./keytar/macos/keytar.node
-          7z a ./dist-cli/bwdc-linux-%_PACKAGE_VERSION%.zip ./dist-cli/linux/bwdc ./keytar/linux/keytar.node
-
-      - name: Version Test
-        run: |
-          Expand-Archive -Path "./dist-cli/bwdc-windows-${env:_PACKAGE_VERSION}.zip" -DestinationPath "./test/windows"
-          $testVersion = Invoke-Expression '& ./test/windows/bwdc.exe -v'
-          echo "version: $env:_PACKAGE_VERSION"
-          echo "testVersion: $testVersion"
-          if($testVersion -ne $env:_PACKAGE_VERSION) {
-            Throw "Version test failed."
-          }
-
-      - name: Create checksums
-        run: |
-          checksum -f="./dist-cli/bwdc-windows-${env:_PACKAGE_VERSION}.zip" `
-            -t sha256 | Out-File ./dist-cli/bwdc-windows-sha256-${env:_PACKAGE_VERSION}.txt
-          checksum -f="./dist-cli/bwdc-macos-${env:_PACKAGE_VERSION}.zip" `
-            -t sha256 | Out-File ./dist-cli/bwdc-macos-sha256-${env:_PACKAGE_VERSION}.txt
-          checksum -f="./dist-cli/bwdc-linux-${env:_PACKAGE_VERSION}.zip" `
-            -t sha256 | Out-File ./dist-cli/bwdc-linux-sha256-${env:_PACKAGE_VERSION}.txt
+      - name: Download latest Linux checksum
+        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
+        with:
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: rc
+          name: bwdc-linux-sha256-${{ env._PACKAGE_VERSION }}.txt
+          path: ./dist-cli
 
       - name: Upload Windows zip release asset
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
-      - name: Download latest Windows zip artifact
+      - name: Download latest RC build artifacts
         uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
         with:
           workflow: build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,52 +80,6 @@ jobs:
           workflow: build.yml
           workflow_conclusion: success
           branch: rc
-          name: bwdc-windows-${{ env._PACKAGE_VERSION }}.zip
-          path: ./dist-cli
-
-      - name: Download latest Mac zip artifact
-        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
-        with:
-          workflow: build.yml
-          workflow_conclusion: success
-          branch: rc
-          name: bwdc-mac-${{ env._PACKAGE_VERSION }}.zip
-          path: ./dist-cli
-
-      - name: Download latest Linux zip artifact
-        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
-        with:
-          workflow: build.yml
-          workflow_conclusion: success
-          branch: rc
-          name: bwdc-linux-${{ env._PACKAGE_VERSION }}.zip
-          path: ./dist-cli
-
-      - name: Download latest Windows checksum
-        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
-        with:
-          workflow: build.yml
-          workflow_conclusion: success
-          branch: rc
-          name: bwdc-windows-sha256-${{ env._PACKAGE_VERSION }}.txt
-          path: ./dist-cli
-
-      - name: Download latest Mac checksum
-        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
-        with:
-          workflow: build.yml
-          workflow_conclusion: success
-          branch: rc
-          name: bwdc-mac-sha256-${{ env._PACKAGE_VERSION }}.txt
-          path: ./dist-cli
-
-      - name: Download latest Linux checksum
-        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
-        with:
-          workflow: build.yml
-          workflow_conclusion: success
-          branch: rc
-          name: bwdc-linux-sha256-${{ env._PACKAGE_VERSION }}.txt
           path: ./dist-cli
 
       - name: Upload Windows zip release asset


### PR DESCRIPTION
## Summary 

Updating the cli job in the release workflow to skip the building and use the latest `rc` build artifacts instead