### PR TITLE
[Account Switching] [Refactor] Implement new account centric services

### DIFF
--- a/src/app/accounts/apiKey.component.ts
+++ b/src/app/accounts/apiKey.component.ts
@@ -1,6 +1,5 @@
 import {
     Component,
-    ComponentFactoryResolver,
     Input,
     ViewChild,
     ViewContainerRef,
@@ -9,7 +8,7 @@ import { Router } from '@angular/router';
 
 import { EnvironmentComponent } from './environment.component';
 
-import { ApiKeyService } from 'jslib-common/abstractions/apiKey.service';
+import { ActiveAccountService } from 'jslib-common/abstractions/activeAccount.service';
 import { AuthService } from 'jslib-common/abstractions/auth.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
@@ -18,6 +17,8 @@ import { ModalService } from 'jslib-angular/services/modal.service';
 
 import { Utils } from 'jslib-common/misc/utils';
 import { ConfigurationService } from '../../services/configuration.service';
+
+import { StorageKey } from 'jslib-common/enums/storageKey';
 
 @Component({
     selector: 'app-apiKey',
@@ -32,8 +33,8 @@ export class ApiKeyComponent {
     successRoute = '/tabs/dashboard';
     showSecret: boolean = false;
 
-    constructor(private authService: AuthService, private apiKeyService: ApiKeyService, private router: Router,
-        private i18nService: I18nService, private componentFactoryResolver: ComponentFactoryResolver,
+    constructor(private authService: AuthService, private activeAccount: ActiveAccountService,
+        private router: Router, private i18nService: I18nService,
         private configurationService: ConfigurationService, private platformUtilsService: PlatformUtilsService,
         private modalService: ModalService) { }
 
@@ -64,7 +65,7 @@ export class ApiKeyComponent {
         try {
             this.formPromise = this.authService.logInApiKey(this.clientId, this.clientSecret);
             await this.formPromise;
-            const organizationId = await this.apiKeyService.getEntityId();
+            const organizationId = await this.activeAccount.getInformation<string>(StorageKey.EntityId);
             await this.configurationService.saveOrganizationId(organizationId);
             this.router.navigate([this.successRoute]);
         } catch { }
@@ -77,6 +78,7 @@ export class ApiKeyComponent {
             modalRef.close();
         });
     }
+
     toggleSecret() {
         this.showSecret = !this.showSecret;
         document.getElementById('client_secret').focus();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,17 +2,14 @@ import {
     BodyOutputType,
     Toast,
     ToasterConfig,
-    ToasterContainerComponent,
     ToasterService,
 } from 'angular2-toaster';
 
 import {
     Component,
-    ComponentFactoryResolver,
     NgZone,
     OnInit,
     SecurityContext,
-    Type,
     ViewChild,
     ViewContainerRef,
 } from '@angular/core';
@@ -21,14 +18,11 @@ import { Router } from '@angular/router';
 
 import { BroadcasterService } from 'jslib-angular/services/broadcaster.service';
 
-import { ApiService } from 'jslib-common/abstractions/api.service';
 import { AuthService } from 'jslib-common/abstractions/auth.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { MessagingService } from 'jslib-common/abstractions/messaging.service';
 import { StateService } from 'jslib-common/abstractions/state.service';
-import { StorageService } from 'jslib-common/abstractions/storage.service';
 import { TokenService } from 'jslib-common/abstractions/token.service';
-import { UserService } from 'jslib-common/abstractions/user.service';
 
 import { ConfigurationService } from '../services/configuration.service';
 import { SyncService } from '../services/sync.service';
@@ -53,16 +47,12 @@ export class AppComponent implements OnInit {
         limit: 5,
     });
 
-    private lastActivity: number = null;
-
-    constructor(private broadcasterService: BroadcasterService, private userService: UserService,
-        private tokenService: TokenService, private storageService: StorageService,
+    constructor(private broadcasterService: BroadcasterService, private tokenService: TokenService,
         private authService: AuthService, private router: Router,
         private toasterService: ToasterService, private i18nService: I18nService,
         private sanitizer: DomSanitizer, private ngZone: NgZone,
-        private componentFactoryResolver: ComponentFactoryResolver, private messagingService: MessagingService,
-        private configurationService: ConfigurationService, private syncService: SyncService,
-        private stateService: StateService, private apiService: ApiService) {
+        private messagingService: MessagingService, private configurationService: ConfigurationService,
+        private syncService: SyncService, private stateService: StateService) {
         (window as any).BitwardenToasterService = toasterService;
     }
 
@@ -129,11 +119,7 @@ export class AppComponent implements OnInit {
     }
 
     private async logOut(expired: boolean) {
-        const userId = await this.userService.getUserId();
-
         await this.tokenService.clearToken();
-        await this.userService.clear();
-
         this.authService.logOut(async () => {
             if (expired) {
                 this.toasterService.popAsync('warning', this.i18nService.t('loggedOut'),

--- a/src/app/services/auth-guard.service.ts
+++ b/src/app/services/auth-guard.service.ts
@@ -1,20 +1,16 @@
 import { Injectable } from '@angular/core';
-import {
-    CanActivate,
-    Router,
-} from '@angular/router';
-import { ApiKeyService } from 'jslib-common/abstractions/apiKey.service';
+import { CanActivate } from '@angular/router';
 
+import { ActiveAccountService } from 'jslib-common/abstractions/activeAccount.service';
 import { MessagingService } from 'jslib-common/abstractions/messaging.service';
 
 @Injectable()
 export class AuthGuardService implements CanActivate {
-    constructor(private apiKeyService: ApiKeyService, private router: Router,
-        private messagingService: MessagingService) { }
+    constructor(private activeAccount: ActiveAccountService, private messagingService: MessagingService) { }
 
     async canActivate() {
-        const isAuthed = await this.apiKeyService.isAuthenticated();
-        if (!isAuthed) {
+        if (!this.activeAccount.isAuthenticated) {
+            console.log('logging out');
             this.messagingService.send('logout');
             return false;
         }

--- a/src/app/services/launch-guard.service.ts
+++ b/src/app/services/launch-guard.service.ts
@@ -4,15 +4,14 @@ import {
     Router,
 } from '@angular/router';
 
-import { ApiKeyService } from 'jslib-common/abstractions/apiKey.service';
+import { ActiveAccountService } from 'jslib-common/abstractions/activeAccount.service';
 
 @Injectable()
 export class LaunchGuardService implements CanActivate {
-    constructor(private apiKeyService: ApiKeyService, private router: Router) { }
+    constructor(private activeAccount: ActiveAccountService, private router: Router) { }
 
     async canActivate() {
-        const isAuthed = await this.apiKeyService.isAuthenticated();
-        if (!isAuthed) {
+        if (!this.activeAccount.isAuthenticated) {
             return true;
         }
 

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -22,41 +22,44 @@ import { BroadcasterService } from 'jslib-angular/services/broadcaster.service';
 import { ModalService } from 'jslib-angular/services/modal.service';
 import { ValidationService } from 'jslib-angular/services/validation.service';
 
-import { ApiKeyService } from 'jslib-common/services/apiKey.service';
+import { AccountsManagementService } from 'jslib-common/services/accountsManagement.service';
+import { ActiveAccountService } from 'jslib-common/services/activeAccount.service';
 import { AppIdService } from 'jslib-common/services/appId.service';
-import { ConstantsService } from 'jslib-common/services/constants.service';
 import { ContainerService } from 'jslib-common/services/container.service';
 import { CryptoService } from 'jslib-common/services/crypto.service';
 import { EnvironmentService } from 'jslib-common/services/environment.service';
+import { OrganizationService } from 'jslib-common/services/organization.service';
 import { PasswordGenerationService } from 'jslib-common/services/passwordGeneration.service';
 import { PolicyService } from 'jslib-common/services/policy.service';
+import { ProviderService } from 'jslib-common/services/provider.service';
 import { StateService } from 'jslib-common/services/state.service';
+import { StoreService } from 'jslib-common/services/store.service';
 import { TokenService } from 'jslib-common/services/token.service';
-import { UserService } from 'jslib-common/services/user.service';
 
 import { NodeCryptoFunctionService } from 'jslib-node/services/nodeCryptoFunction.service';
 
+import { AccountsManagementService as AccountsManagementServiceAbstraction } from 'jslib-common/abstractions/accountsManagement.service';
+import { ActiveAccountService as ActiveAccountServiceAbstraction } from 'jslib-common/abstractions/activeAccount.service';
 import { ApiService as ApiServiceAbstraction } from 'jslib-common/abstractions/api.service';
-import { ApiKeyService as ApiKeyServiceAbstraction } from 'jslib-common/abstractions/apiKey.service';
 import { AuthService as AuthServiceAbstraction } from 'jslib-common/abstractions/auth.service';
-import { CryptoService as CryptoServiceAbstraction } from 'jslib-common/abstractions/crypto.service';
 import { CryptoFunctionService as CryptoFunctionServiceAbstraction } from 'jslib-common/abstractions/cryptoFunction.service';
+import { CryptoService as CryptoServiceAbstraction } from 'jslib-common/abstractions/crypto.service';
 import { EnvironmentService as EnvironmentServiceAbstraction } from 'jslib-common/abstractions/environment.service';
 import { I18nService as I18nServiceAbstraction } from 'jslib-common/abstractions/i18n.service';
 import { LogService as LogServiceAbstraction } from 'jslib-common/abstractions/log.service';
 import { MessagingService as MessagingServiceAbstraction } from 'jslib-common/abstractions/messaging.service';
-import {
-    PasswordGenerationService as PasswordGenerationServiceAbstraction,
-} from 'jslib-common/abstractions/passwordGeneration.service';
+import { OrganizationService as OrganizationServiceAbstraction } from 'jslib-common/abstractions/organization.service';
+import { PasswordGenerationService as PasswordGenerationServiceAbstraction, } from 'jslib-common/abstractions/passwordGeneration.service';
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from 'jslib-common/abstractions/platformUtils.service';
 import { PolicyService as PolicyServiceAbstraction } from 'jslib-common/abstractions/policy.service';
+import { ProviderService as ProviderServiceAbstraction } from 'jslib-common/abstractions/provider.service';
 import { StateService as StateServiceAbstraction } from 'jslib-common/abstractions/state.service';
 import { StorageService as StorageServiceAbstraction } from 'jslib-common/abstractions/storage.service';
 import { TokenService as TokenServiceAbstraction } from 'jslib-common/abstractions/token.service';
-import { UserService as UserServiceAbstraction } from 'jslib-common/abstractions/user.service';
 
 import { ApiService, refreshToken } from '../../services/api.service';
 import { AuthService } from '../../services/auth.service';
+import { StorageKey } from 'jslib-common/enums/storageKey';
 
 const logService = new ElectronLogService();
 const i18nService = new I18nService(window.navigator.language, './locales');
@@ -64,31 +67,40 @@ const stateService = new StateService();
 const broadcasterService = new BroadcasterService();
 const messagingService = new ElectronRendererMessagingService(broadcasterService);
 const storageService: StorageServiceAbstraction = new ElectronRendererStorageService();
-const platformUtilsService = new ElectronPlatformUtilsService(i18nService, messagingService, false, storageService);
 const secureStorageService: StorageServiceAbstraction = new ElectronRendererSecureStorageService();
+const storeService = new StoreService(storageService, secureStorageService);
+const accountsManagementService: AccountsManagementServiceAbstraction = new AccountsManagementService(storageService, secureStorageService);
+const activeAccount: ActiveAccountServiceAbstraction = new ActiveAccountService(accountsManagementService, storeService);
+const organizationService: OrganizationServiceAbstraction = new OrganizationService(activeAccount);
+const providerService: ProviderServiceAbstraction = new ProviderService(activeAccount);
+const platformUtilsService = new ElectronPlatformUtilsService(i18nService, messagingService, 
+    false, storageService,
+    activeAccount);
 const cryptoFunctionService: CryptoFunctionServiceAbstraction = new NodeCryptoFunctionService();
-const cryptoService = new CryptoService(storageService, secureStorageService, cryptoFunctionService,
-    platformUtilsService, logService);
+const cryptoService = new CryptoService(cryptoFunctionService, platformUtilsService,
+    logService, activeAccount);
 const appIdService = new AppIdService(storageService);
-const tokenService = new TokenService(storageService);
-const environmentService = new EnvironmentService(storageService);
+const tokenService = new TokenService(activeAccount);
+const environmentService = new EnvironmentService(activeAccount);
 const apiService = new ApiService(tokenService, platformUtilsService, environmentService, refreshTokenCallback,
     async (expired: boolean) => messagingService.send('logout', { expired: expired }));
-const userService = new UserService(tokenService, storageService);
-const apiKeyService = new ApiKeyService(tokenService, storageService);
 const containerService = new ContainerService(cryptoService);
-const authService = new AuthService(cryptoService, apiService, userService, tokenService, appIdService,
-    i18nService, platformUtilsService, messagingService, null, logService, apiKeyService, false);
+const authService = new AuthService(cryptoService, apiService,
+    tokenService, appIdService,
+    i18nService, platformUtilsService, 
+    messagingService, null,
+    logService, accountsManagementService,
+    activeAccount, false);
 const configurationService = new ConfigurationService(storageService, secureStorageService);
 const syncService = new SyncService(configurationService, logService, cryptoFunctionService, apiService,
     messagingService, i18nService, environmentService);
-const passwordGenerationService = new PasswordGenerationService(cryptoService, storageService, null);
-const policyService = new PolicyService(userService, storageService);
+const policyService = new PolicyService(activeAccount, organizationService, apiService);
+const passwordGenerationService = new PasswordGenerationService(cryptoService, policyService, activeAccount);
 
 containerService.attachToWindow(window);
 
 function refreshTokenCallback(): Promise<any> {
-    return refreshToken(apiKeyService, authService);
+    return refreshToken(activeAccount, authService);
 }
 
 export function initFactory(): Function {
@@ -102,7 +114,7 @@ export function initFactory(): Function {
         window.document.title = i18nService.t('bitwardenDirectoryConnector');
 
         let installAction = null;
-        const installedVersion = await storageService.get<string>(ConstantsService.installedVersionKey);
+        const installedVersion = await storageService.get<string>(StorageKey.InstalledVersion);
         const currentVersion = await platformUtilsService.getApplicationVersion();
         if (installedVersion == null) {
             installAction = 'install';
@@ -111,11 +123,11 @@ export function initFactory(): Function {
         }
 
         if (installAction != null) {
-            await storageService.save(ConstantsService.installedVersionKey, currentVersion);
+            await storageService.save(StorageKey.InstalledVersion, currentVersion);
         }
 
         window.setTimeout(async () => {
-            if (await userService.isAuthenticated()) {
+            if (activeAccount.isAuthenticated) {
                 const profile = await apiService.getProfile();
                 stateService.save('profileOrganizations', profile.organizations);
             }
@@ -140,8 +152,10 @@ export function initFactory(): Function {
         { provide: CryptoServiceAbstraction, useValue: cryptoService },
         { provide: PlatformUtilsServiceAbstraction, useValue: platformUtilsService },
         { provide: ApiServiceAbstraction, useValue: apiService },
-        { provide: UserServiceAbstraction, useValue: userService },
-        { provide: ApiKeyServiceAbstraction, useValue: apiKeyService },
+        { provide: ActiveAccountServiceAbstraction, useValue: activeAccount },
+        { provide: AccountsManagementServiceAbstraction, useValue: accountsManagementService },
+        { provide: OrganizationServiceAbstraction, useValue: organizationService },
+        { provide: ProviderServiceAbstraction, useValue: providerService },
         { provide: MessagingServiceAbstraction, useValue: messagingService },
         { provide: BroadcasterService, useValue: broadcasterService },
         { provide: StorageServiceAbstraction, useValue: storageService },

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ export class Main {
         this.i18nService = new I18nService('en', './locales/');
         this.storageService = new ElectronStorageService(app.getPath('userData'));
 
-        this.windowMain = new WindowMain(this.storageService, false, 800, 600, arg => this.processDeepLink(arg), null);
+        this.windowMain = new WindowMain(this.storageService, this.logService, false, 800, 600, arg => this.processDeepLink(arg), null);
         this.menuMain = new MenuMain(this);
         this.updaterMain = new UpdaterMain(this.i18nService, this.windowMain, 'directory-connector', () => {
             this.messagingService.send('checkingForUpdate');

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -1,15 +1,17 @@
-import { ApiKeyService } from 'jslib-common/abstractions/apiKey.service';
+import { ActiveAccountService } from 'jslib-common/abstractions/activeAccount.service';
 import { AuthService } from 'jslib-common/abstractions/auth.service';
 import { EnvironmentService } from 'jslib-common/abstractions/environment.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
 import { TokenService } from 'jslib-common/abstractions/token.service';
 
+import { StorageKey } from 'jslib-common/enums/storageKey';
+
 import { ApiService as ApiServiceBase } from 'jslib-common/services/api.service';
 
-export async function refreshToken(apiKeyService: ApiKeyService, authService: AuthService) {
+export async function refreshToken(activeAccount: ActiveAccountService, authService: AuthService) {
     try {
-        const clientId = await apiKeyService.getClientId();
-        const clientSecret = await apiKeyService.getClientSecret();
+        const clientId = await activeAccount.getInformation<string>(StorageKey.ClientId);
+        const clientSecret = await activeAccount.getInformation<string>(StorageKey.ClientSecret);
         if (clientId != null && clientSecret != null) {
             await authService.logInApiKey(clientId, clientSecret);
         }


### PR DESCRIPTION
### Related Work
* **[jslib Dependency]** https://github.com/bitwarden/jslib/pull/491
* [Asana Task](https://app.asana.com/0/1200804338582616/1200940942987458)

Several refactors were done on the data storage layer of jslib to support Account Switching for desktop.
These changes have been implemented here for parity across clients, improved readability, and to make it easier
to add Account Switching to other clients later if desired.

### Object
> Refactor BW clients to use new data storage access patterns that are being used by desktop to achieve Account Switching for that client.

### Code Changes
* The UserService was removed, and so all references have been replaced with the new access points for that data (activeAccount and organizationService most often)
* The StorageService is now considered a "global" scope, where as we have a new "account" scope to consider. Any "account" scope storage items I have moved to saving with
an ActiveAccountService instance instead of a StorageService instance.
* ConstantsServices have been removed and replaced with a StorageKey enum that holds keys that were in ConstantServices and in other feature scoped services.
* The Directory Connector specific auth services was updated to use account based services

### Testing Considerations
> There are no functional changes here, but the storage mechanism for the entire app was swapped. We should perform a regression here, specifically surrounding login and settings.