### PR TITLE
Change Release workflow to allow releases from 'rc' and 'hotfix' branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
           echo "version: $_PACKAGE_VERSION"
           echo "testVersion: $testVersion"
 
-          if [ "$testVersion" != "$_PACKAGE_VERSION" ]; then 
+          if [ "$testVersion" != "$_PACKAGE_VERSION" ]; then
             echo "Version test failed."
             exit 1
           fi
@@ -198,7 +198,7 @@ jobs:
           echo "version: $_PACKAGE_VERSION"
           echo "testVersion: $testVersion"
 
-          if [ "$testVersion" != "$_PACKAGE_VERSION" ]; then 
+          if [ "$testVersion" != "$_PACKAGE_VERSION" ]; then
             echo "Version test failed."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,15 @@ jobs:
     steps:
       - name: Branch check
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/release" ]]; then
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix" ]]; then
             echo "==================================="
-            echo "[!] Can only release from the 'release' branch"
+            echo "[!] Can only release from the 'rc' or 'hotfix' branches"
             echo "==================================="
             exit 1
           fi
 
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-        with:
-          ref: release
 
       - name: Retrieve Directory Connector release version
         id: retrieve-version
@@ -44,12 +42,18 @@ jobs:
           fi
         shell: bash
 
+      - name: Get branch name
+        id: branch
+        run: |
+          BRANCH_NAME=$(basename ${{ github.ref }})
+          echo "::set-output name=branch-name::$BRANCH_NAME"
+
       - name: Download all artifacts
         uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
         with:
           workflow: build.yml
           workflow_conclusion: success
-          branch: release
+          branch: ${{ steps.branch.outputs.branch-name }}
 
       - name: Create release
         uses: ncipollo/release-action@95215a3cb6e6a1908b3c44e00b4fdb15548b1e09  # v2.8.5


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Changes our `release` workflow to allow releases from only `rc` and `hotfix` branches.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **release.yml:** Adds step to the `setup` job to find the branch name and set it as an output for the job.  Changes the rest of the workflow to use that new branch variable.
* **build.yml:** Changes are from linter suggestions.

## Before you submit
- [X] I have checked for workflow **linting** errors (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
