### PR TITLE
Add Azure Identity Authority Selector

### DIFF
--- a/src/app/tabs/settings.component.html
+++ b/src/app/tabs/settings.component.html
@@ -135,6 +135,14 @@
                 </div>
                 <div [hidden]="directory != directoryType.AzureActiveDirectory">
                     <div class="form-group">
+                        <label for="identityAuthority">{{'identityAuthority' | i18n}}</label>
+                        <select class="form-control" id="identityAuthority" name="IdentityAuthority"
+                            [(ngModel)]="azure.identityAuthority">
+                            <option value="login.microsoftonline.com">Azure AD Public</option>
+                            <option value="login.microsoftonline.us">Azure AD Government</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
                         <label for="tenant">{{'tenant' | i18n}}</label>
                         <input type="text" class="form-control" id="tenant" name="Tenant" [(ngModel)]="azure.tenant">
                         <small class="text-muted form-text">{{'ex' | i18n}} companyad.onmicrosoft.com</small>

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -354,6 +354,9 @@
     "rootPath": {
         "message": "Root Path"
     },
+    "identityAuthority": {
+        "message": "Identity Authority"
+    },
     "tenant": {
         "message": "Tenant"
     },

--- a/src/models/azureConfiguration.ts
+++ b/src/models/azureConfiguration.ts
@@ -1,4 +1,5 @@
 export class AzureConfiguration {
+    identityAuthority: string;
     tenant: string;
     applicationId: string;
     key: string;

--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -17,6 +17,8 @@ import { IDirectoryService } from './directory.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { LogService } from 'jslib-common/abstractions/log.service';
 
+const AzurePublicIdentityAuhtority = 'login.microsoftonline.com';
+
 const NextLink = '@odata.nextLink';
 const DeltaLink = '@odata.deltaLink';
 const ObjectType = '@odata.type';
@@ -385,10 +387,12 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
         this.client = graph.Client.init({
             authProvider: done => {
                 if (this.dirConfig.applicationId == null || this.dirConfig.key == null ||
-                    this.dirConfig.tenant == null || this.dirConfig.identityAuthority == null) {
+                    this.dirConfig.tenant == null) {
                     done(new Error(this.i18nService.t('dirConfigIncomplete')), null);
                     return;
                 }
+
+                const identityAuthority = this.dirConfig.identityAuthority != null ? this.dirConfig.identityAuthority : AzurePublicIdentityAuhtority;
 
                 if (!this.accessTokenIsExpired()) {
                     done(null, this.accessToken);
@@ -406,7 +410,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
                 });
 
                 const req = https.request({
-                    host: this.dirConfig.identityAuthority,
+                    host: identityAuthority,
                     path: '/' + this.dirConfig.tenant + '/oauth2/v2.0/token',
                     method: 'POST',
                     headers: {

--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -18,6 +18,7 @@ import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { LogService } from 'jslib-common/abstractions/log.service';
 
 const AzurePublicIdentityAuhtority = 'login.microsoftonline.com';
+const AzureGovermentIdentityAuhtority = 'login.microsoftonline.us';
 
 const NextLink = '@odata.nextLink';
 const DeltaLink = '@odata.deltaLink';
@@ -393,6 +394,10 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
                 }
 
                 const identityAuthority = this.dirConfig.identityAuthority != null ? this.dirConfig.identityAuthority : AzurePublicIdentityAuhtority;
+                if (identityAuthority !== AzurePublicIdentityAuhtority && identityAuthority !== AzureGovermentIdentityAuhtority) {
+                    done(new Error(this.i18nService.t('dirConfigIncomplete')), null);
+                    return;
+                }
 
                 if (!this.accessTokenIsExpired()) {
                     done(null, this.accessToken);

--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -385,7 +385,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
         this.client = graph.Client.init({
             authProvider: done => {
                 if (this.dirConfig.applicationId == null || this.dirConfig.key == null ||
-                    this.dirConfig.tenant == null) {
+                    this.dirConfig.tenant == null || this.dirConfig.identityAuthority == null) {
                     done(new Error(this.i18nService.t('dirConfigIncomplete')), null);
                     return;
                 }
@@ -406,7 +406,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
                 });
 
                 const req = https.request({
-                    host: 'login.microsoftonline.com',
+                    host: this.dirConfig.identityAuthority,
                     path: '/' + this.dirConfig.tenant + '/oauth2/v2.0/token',
                     method: 'POST',
                     headers: {


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Add a selector to the AzureAD sync settings to let a user choose which Azure AD Identity Authority they want to use.

Further information on Azure Identity Authorities can be found [here](https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-plan-identity#choosing-your-identity-authority)

Asana task: https://app.asana.com/0/1169444489336079/1201382398383483/f

## Code changes
* **src/models/azureConfiguration.ts:** Extended the model to get/set the selected idendityAuthority
* **src/app/tabs/settings.component.html:** Added a dropdown to the Azure AD sync settings to select the Identity Authority 
* **src/locales/en/messages.json:** Added text for the label in the Azure AD sync settings
* **src/services/azure-directory.service.ts:** 
    - Use new value from configuration to set the host on http-requests
    - Added a fallback for existing customers, so they don't have to set the setting immediately after an update
    - Validate that the selected Identity Authority is valid (Either Azure Public or Azure Goverment)

## Screenshots
![azure-settings](https://user-images.githubusercontent.com/2670567/142283412-c4dd00e5-d1bf-47ff-8b99-2fbe49c29514.PNG)

## Testing requirements
Should be able to select and persist the Azure AD sync settings.
Should be able to sync with Azure AD Public Authority/Azure Goverment Authority
Timothy or Jordan should be able to support

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
