### PR TITLE
Don't flag deleted users as duplicates

### DIFF
--- a/src/services/ldap-directory.service.ts
+++ b/src/services/ldap-directory.service.ts
@@ -79,7 +79,7 @@ export class LdapDirectoryService implements IDirectoryService {
         }
 
         try {
-            let deletedFilter = this.buildBaseFilter(this.syncConfig.userObjectClass, '(isDeleted=TRUE)');
+            let deletedFilter = this.buildBaseFilter(this.syncConfig.userObjectClass, '(isDeleted=TRUE)' + this.syncConfig.userFilter);
             deletedFilter = this.buildRevisionFilter(deletedFilter, force, lastSync);
 
             const deletedPath = this.makeSearchPath('CN=Deleted Objects');
@@ -107,10 +107,15 @@ export class LdapDirectoryService implements IDirectoryService {
         user.externalId = this.getExternalId(searchEntry, user.referenceId);
         user.disabled = this.entryDisabled(searchEntry);
         user.email = this.getAttr(searchEntry, this.syncConfig.userEmailAttribute);
+        console.log(user.email);
+        if (user.email == null) {
+            console.log(this.syncConfig.useEmailPrefixSuffix, this.syncConfig.emailPrefixAttribute, this.syncConfig.emailSuffix)
+        }
         if (user.email == null && this.syncConfig.useEmailPrefixSuffix &&
             this.syncConfig.emailPrefixAttribute != null && this.syncConfig.emailSuffix != null) {
             const prefixAttr = this.getAttr(searchEntry, this.syncConfig.emailPrefixAttribute);
             if (prefixAttr != null) {
+                console.log('Building email', prefixAttr);
                 user.email = prefixAttr + this.syncConfig.emailSuffix;
             }
         }

--- a/src/services/ldap-directory.service.ts
+++ b/src/services/ldap-directory.service.ts
@@ -79,7 +79,7 @@ export class LdapDirectoryService implements IDirectoryService {
         }
 
         try {
-            let deletedFilter = this.buildBaseFilter(this.syncConfig.userObjectClass, '(isDeleted=TRUE)' + this.syncConfig.userFilter);
+            let deletedFilter = this.buildBaseFilter(this.syncConfig.userObjectClass, '(isDeleted=TRUE)');
             deletedFilter = this.buildRevisionFilter(deletedFilter, force, lastSync);
 
             const deletedPath = this.makeSearchPath('CN=Deleted Objects');
@@ -107,15 +107,10 @@ export class LdapDirectoryService implements IDirectoryService {
         user.externalId = this.getExternalId(searchEntry, user.referenceId);
         user.disabled = this.entryDisabled(searchEntry);
         user.email = this.getAttr(searchEntry, this.syncConfig.userEmailAttribute);
-        console.log(user.email);
-        if (user.email == null) {
-            console.log(this.syncConfig.useEmailPrefixSuffix, this.syncConfig.emailPrefixAttribute, this.syncConfig.emailSuffix)
-        }
         if (user.email == null && this.syncConfig.useEmailPrefixSuffix &&
             this.syncConfig.emailPrefixAttribute != null && this.syncConfig.emailSuffix != null) {
             const prefixAttr = this.getAttr(searchEntry, this.syncConfig.emailPrefixAttribute);
             if (prefixAttr != null) {
-                console.log('Building email', prefixAttr);
                 user.email = prefixAttr + this.syncConfig.emailSuffix;
             }
         }

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -127,7 +127,7 @@ export class SyncService {
                 }
             } else {
                 if (!u.deleted) {
-                    // UserEntrys that are not deleted but there's a deleted entry with same email error
+                    // Check that active UserEntry does not conflict with a deleted UserEntry
                     if (processedDeletedUsers.has(u.email)) {
                         duplicateEmails.push(u.email);
                     } else {

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -115,20 +115,30 @@ export class SyncService {
     private removeDuplicateUsers(users: UserEntry[]) {
         const uniqueUsers = new Array<UserEntry>();
         const processedUsers = new Map<string, string>();
+        const processedDeletedUsers = new Map<string, string>();
         const duplicateEmails = new Array<string>();
 
         // UserEntrys with the same email are ignored if their properties are the same
-        // UserEntrys with the same email but different properties will throw an error
+        // UserEntrys with the same email but different properties will throw an error 
         users.forEach(u => {
             if (processedUsers.has(u.email)) {
                 if (processedUsers.get(u.email) !== JSON.stringify(u)) {
-                    if (!u.deleted) {
-                        duplicateEmails.push(u.email);
-                    }
+                    duplicateEmails.push(u.email);
                 }
             } else {
-                uniqueUsers.push(u);
-                processedUsers.set(u.email, JSON.stringify(u));
+                if (!u.deleted) {
+                    // UserEntrys that are not deleted but there's a deleted entry with same email error
+                    if (processedDeletedUsers.has(u.email)) {
+                        duplicateEmails.push(u.email);
+                    } else {
+                        processedUsers.set(u.email, JSON.stringify(u));
+                        uniqueUsers.push(u);
+                    }
+                } else {
+                    // UserEntrys with the same email but are all deleted are ignored but tracked
+                    processedDeletedUsers.set(u.email, JSON.stringify(u));
+                    uniqueUsers.push(u);
+                }
             }
         });
 

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -119,7 +119,7 @@ export class SyncService {
         const duplicateEmails = new Array<string>();
 
         // UserEntrys with the same email are ignored if their properties are the same
-        // UserEntrys with the same email but different properties will throw an error 
+        // UserEntrys with the same email but different properties will throw an error, unless they are all in a deleted state.
         users.forEach(u => {
             if (processedActiveUsers.has(u.email)) {
                 if (processedActiveUsers.get(u.email) !== JSON.stringify(u)) {

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -122,7 +122,9 @@ export class SyncService {
         users.forEach(u => {
             if (processedUsers.has(u.email)) {
                 if (processedUsers.get(u.email) != JSON.stringify(u)) {
-                    duplicateEmails.push(u.email);
+                    if (!u.deleted) {
+                        duplicateEmails.push(u.email);
+                    }
                 }
             } else {
                 uniqueUsers.push(u);

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -121,7 +121,7 @@ export class SyncService {
         // UserEntrys with the same email but different properties will throw an error
         users.forEach(u => {
             if (processedUsers.has(u.email)) {
-                if (processedUsers.get(u.email) != JSON.stringify(u)) {
+                if (processedUsers.get(u.email) !== JSON.stringify(u)) {
                     if (!u.deleted) {
                         duplicateEmails.push(u.email);
                     }

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -135,7 +135,7 @@ export class SyncService {
                         uniqueUsers.push(u);
                     }
                 } else {
-                    // UserEntrys with the same email but are all deleted are ignored but tracked
+                    // UserEntrys with duplicate email will not throw an error if they are all deleted. They will be synced.
                     processedDeletedUsers.set(u.email, JSON.stringify(u));
                     uniqueUsers.push(u);
                 }

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -114,15 +114,15 @@ export class SyncService {
 
     private removeDuplicateUsers(users: UserEntry[]) {
         const uniqueUsers = new Array<UserEntry>();
-        const processedUsers = new Map<string, string>();
+        const processedActiveUsers = new Map<string, string>();
         const processedDeletedUsers = new Map<string, string>();
         const duplicateEmails = new Array<string>();
 
         // UserEntrys with the same email are ignored if their properties are the same
         // UserEntrys with the same email but different properties will throw an error 
         users.forEach(u => {
-            if (processedUsers.has(u.email)) {
-                if (processedUsers.get(u.email) !== JSON.stringify(u)) {
+            if (processedActiveUsers.has(u.email)) {
+                if (processedActiveUsers.get(u.email) !== JSON.stringify(u)) {
                     duplicateEmails.push(u.email);
                 }
             } else {
@@ -131,7 +131,7 @@ export class SyncService {
                     if (processedDeletedUsers.has(u.email)) {
                         duplicateEmails.push(u.email);
                     } else {
-                        processedUsers.set(u.email, JSON.stringify(u));
+                        processedActiveUsers.set(u.email, JSON.stringify(u));
                         uniqueUsers.push(u);
                     }
                 } else {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixes an issue where a duplicate email error is being thrown. After a lot of investigation, the root cause of this has been determined to be deleted users; AD unfortunately allows emails to be duplicated for deleted users. Additional context here: https://app.asana.com/0/1169444489336079/1201410771133282/f


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **sync.service.ts** Add a condition to only add a user to the duplicateEmails array if the user is not deleted.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Please test around the syncing functionality and make sure that duplicates aren't flagged unexpectedly.
The change was done in a shared function in the sync service that all directory types use.

These are the expected outcomes when testing for duplicate emails:
- Two or more deleted users with the same email will not throw a duplicate email error.
- If an active user and a deleted user share the same email, a duplicate email error will be thrown.
- If two or more active users share an email, a duplicate email error will be thrown.

Feel free to reach out to me (Robyn) for some ways to set up the above conditions in Active Directory.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
