### PR TITLE
override pushAccounts to not delete account from state

### DIFF
--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -532,4 +532,12 @@ export class StateService extends BaseStateService<Account> implements StateServ
     storedState.accounts[account.profile.userId] = account;
     await this.saveStateToStorage(storedState, await this.defaultOnDiskLocalOptions());
   }
+
+  protected async pushAccounts(): Promise<void> {
+    if (this.state?.accounts == null || Object.keys(this.state.accounts).length < 1) {
+      this.accounts.next(null);
+      return;
+    }
+    this.accounts.next(this.state.accounts);
+  }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix an issue after the state service refactor where directory settings were being cleared on logout from the cli.
[Asana task
](https://app.asana.com/0/1200804338582616/1201593355163718/f)
## Code changes

- **state.service.ts** Override `pushAccounts()` from jslib state service to not call `pruneInMemoryAccounts()`. This call was clearing the directory settings stored in the state. 

The reason we need to do this is because the CLI uses commands and is not like the other clients, so state service is inited on every call to a command.
There is a method called on the init of state service that is loadsStateFromDisk. In that method, when pushAccounts() is called, the user isn’t authenticated quite yet on login, so the account is deleted. Then the user is logged in and added to the accounts array, and boom all of the settings are gone. 

## Testing requirements

Ensure that directory settings are not cleared after logging out and then logging back in.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
