### PR TITLE
Fix date returning as a string

### DIFF
--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -440,9 +440,10 @@ export class StateService extends BaseStateService<Account> implements StateServ
   }
 
   async getLastUserSync(options?: StorageOptions): Promise<Date> {
-    return (
+    const userSyncDate = (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
     )?.directorySettings?.lastUserSync;
+    return userSyncDate ? new Date(userSyncDate) : null;
   }
 
   async setLastUserSync(value: Date, options?: StorageOptions): Promise<void> {
@@ -457,9 +458,10 @@ export class StateService extends BaseStateService<Account> implements StateServ
   }
 
   async getLastGroupSync(options?: StorageOptions): Promise<Date> {
-    return (
+    const groupSyncDate = (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
     )?.directorySettings?.lastGroupSync;
+    return groupSyncDate ? new Date(groupSyncDate) : null;
   }
 
   async setLastGroupSync(value: Date, options?: StorageOptions): Promise<void> {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Last user sync and last group sync dates were being returned as strings from the new state service changes. I noticed this  on the last-sync command when `toISOString()` is called on the dates. This also presented an issue in the ldap and okta directory services when the filters are built.

## Code changes

- **src/services/state.service.ts** Return last sync values as `Date` if they are not null.

## Testing requirements

Ensure that the `last-sync command` in the cli does not fail.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
