### PR TITLE
Only get users for includeGroup filter

### DIFF
--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -148,7 +148,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
             continue;
           }
 
-          // filterOutUserResult should only be called if the filter is includeUser or excludeUser
+          // Deleted users cannot be filtered by group in Azure AD so we only apply user filters if required
           if (
             setFilter != null &&
             (setFilter[0] === UserSetType.IncludeUser || setFilter[0] === UserSetType.ExcludeUser)

--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -88,7 +88,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
     let entries: UserEntry[] = [];
     let users: graphType.User[];
     const setFilter = this.createCustomUserSet(this.syncConfig.userFilter);
-    const usersToExclude = new Set<string>();
+    const userIdsToExclude = new Set<string>();
 
     // Only get users for the groups provided in includeGroup filter
     if (setFilter != null && setFilter[0] === UserSetType.IncludeGroup) {
@@ -96,7 +96,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
       // Get the users in the excludedGroups and filter them out from all users
     } else if (setFilter != null && setFilter[0] === UserSetType.ExcludeGroup) {
       (await this.getUsersByGroups(setFilter)).forEach((user: graphType.User) =>
-        usersToExclude.add(user.id)
+        userIdsToExclude.add(user.id)
       );
       const userReq = this.client.api("/users" + UserSelectParams);
       users = await this.getUsersByResource(userReq);
@@ -105,7 +105,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
       users = await this.getUsersByResource(userReq);
     }
     if (users != null) {
-      entries = await this.buildUserEntries(users, usersToExclude, setFilter);
+      entries = await this.buildUserEntries(users, userIdsToExclude, setFilter);
     }
     return entries;
   }
@@ -366,14 +366,14 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
 
   private async buildUserEntries(
     users: graphType.User[],
-    usersToExclude: Set<string>,
+    userIdsToExclude: Set<string>,
     setFilter: [UserSetType, Set<string>]
   ) {
     const entryIds = new Set<string>();
     const entries: UserEntry[] = [];
 
     for (const user of users) {
-      if (user.id == null || entryIds.has(user.id) || usersToExclude.has(user.id)) {
+      if (user.id == null || entryIds.has(user.id) || userIdsToExclude.has(user.id)) {
         continue;
       }
       const entry = this.buildUser(user);

--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -131,8 +131,8 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
     }
 
     const setFilter = this.createCustomUserSet(this.syncConfig.userFilter);
-    let users: graphType.User[] = res.value;
-    while (res[NextLink] != null) {
+    while (true) {
+      const users: graphType.User[] = res.value;
       if (users != null) {
         for (const user of users) {
           if (user.id == null || entryIds.has(user.id)) {
@@ -165,7 +165,6 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
       } else {
         const nextReq = this.client.api(res[NextLink]);
         res = await nextReq.get();
-        users = res.value;
       }
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Azure AD gets all users for an entire directory regardless of the user filters provided, and then sends a separate api request to Azure per user to determine group membership to filter out unwanted users. This takes an unnecessarily long amount of time for clients that only want to sync a few users and have many many more users in their directory.

With this change, if the `includeGroup` filter is provided, only the users that belong to that group are synced over. This eliminates the need to check group membership on a per user basis.

The `excludeGroup` filter process has also been changed. We now get the users from those groups and use that list to determine whether to filter out the users instead of making a call to get a user's group membership.

I also left the process for getting deleted users the same because those functions rely on the delta token, which is not a supported by the Graph API for group members.

Even with those considerations, for an Azure AD with only 8 users, the sync time was reduced from an average of **2.3 seconds** down to **1 second**. This difference should be even more pronounced for larger instances that only sync over a select number of groups.

Ticket: https://app.asana.com/0/1201211497354246/1201456218559784
Issue: https://github.com/bitwarden/directory-connector/issues/83

## Code changes

- **src/services/azure-directory.service.ts:** 
    - Created a new method `getUsersByGroups`, that is invoked if the provided filter is `includeGroups`. This method calls the Microsoft Graph Api groups transitiveMembers route to get all members of a group, including nested members (members of groups that are in a group) Reference: https://docs.microsoft.com/en-us/graph/api/group-list-transitivemembers?view=graph-rest-1.0&tabs=http
## Testing requirements

Ensure that Azure AD syncs properly with all possible user filters. A lot of stuff changed here so this should be tested thoroughly. This could cause a large number of accounts to be unintentionally (de)provisioned which could cause some headaches.  It would be awesome to benchmark this against a larger Azure AD as well to see the full effects of this change.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
