### PR TITLE
[chore] Update jslib & state services to match

### DIFF
--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -43,6 +43,10 @@ import { AuthService } from "../../services/auth.service";
 import { StateService } from "../../services/state.service";
 import { StateMigrationService } from "../../services/stateMigration.service";
 
+import { Account } from "../../models/account";
+
+import { AccountFactory } from "jslib-common/models/domain/account";
+
 function refreshTokenCallback(injector: Injector) {
   return () => {
     const stateService = injector.get(StateServiceAbstraction);
@@ -197,7 +201,20 @@ export function initFactory(
     },
     {
       provide: StateServiceAbstraction,
-      useClass: StateService,
+      useFactory: (
+        storageService: StorageServiceAbstraction,
+        secureStorageService: StorageServiceAbstraction,
+        logService: LogServiceAbstraction,
+        stateMigrationService: StateMigrationServiceAbstraction
+      ) =>
+        new StateService(
+          storageService,
+          secureStorageService,
+          logService,
+          stateMigrationService,
+          true, // TODO: It seems like we aren't applying this from settings anywhere. Is toggling secure storage working?
+          new AccountFactory(Account)
+        ),
       deps: [
         StorageServiceAbstraction,
         "SECURE_STORAGE",

--- a/src/bwdc.ts
+++ b/src/bwdc.ts
@@ -34,7 +34,6 @@ import { ProviderService } from "jslib-common/services/provider.service";
 import { SearchService } from "jslib-common/services/search.service";
 import { SendService } from "jslib-common/services/send.service";
 import { SettingsService } from "jslib-common/services/settings.service";
-import { SyncService as LoginSyncService } from "jslib-common/services/sync.service";
 import { TokenService } from "jslib-common/services/token.service";
 
 import { StorageService as StorageServiceAbstraction } from "jslib-common/abstractions/storage.service";
@@ -75,7 +74,6 @@ export class Main {
   syncService: SyncService;
   passwordGenerationService: PasswordGenerationService;
   policyService: PolicyService;
-  loginSyncService: LoginSyncService;
   keyConnectorService: KeyConnectorService;
   program: Program;
   stateService: StateService;
@@ -252,24 +250,6 @@ export class Main {
     );
 
     this.providerService = new ProviderService(this.stateService);
-
-    this.loginSyncService = new LoginSyncService(
-      this.apiService,
-      this.settingsService,
-      this.folderService,
-      this.cipherService,
-      this.cryptoService,
-      this.collectionService,
-      this.messagingService,
-      this.policyService,
-      this.sendService,
-      this.logService,
-      this.keyConnectorService,
-      this.stateService,
-      this.organizationService,
-      this.providerService,
-      async (expired: boolean) => this.messagingService.send("logout", { expired: expired })
-    );
 
     this.program = new Program(this);
   }

--- a/src/bwdc.ts
+++ b/src/bwdc.ts
@@ -40,7 +40,10 @@ import { TokenService } from "jslib-common/services/token.service";
 import { StorageService as StorageServiceAbstraction } from "jslib-common/abstractions/storage.service";
 
 import { Program } from "./program";
-import { refreshToken } from "./services/api.service";
+
+import { AccountFactory } from "jslib-common/models/domain/account";
+
+import { Account } from "./models/account";
 
 // tslint:disable-next-line
 const packageJson = require("./package.json");
@@ -130,7 +133,8 @@ export class Main {
       this.secureStorageService,
       this.logService,
       this.stateMigrationService,
-      process.env.BITWARDENCLI_CONNECTOR_PLAINTEXT_SECRETS !== "true"
+      process.env.BITWARDENCLI_CONNECTOR_PLAINTEXT_SECRETS !== "true",
+      new AccountFactory(Account)
     );
 
     this.cryptoService = new CryptoService(

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,10 @@ import { WindowMain } from "jslib-electron/window.main";
 
 import { StateService } from "./services/state.service";
 
+import { AccountFactory } from "jslib-common/models/domain/account";
+
+import { Account } from "./models/account";
+
 export class Main {
   logService: ElectronLogService;
   i18nService: I18nService;
@@ -54,7 +58,14 @@ export class Main {
     this.logService = new ElectronLogService(null, app.getPath("userData"));
     this.i18nService = new I18nService("en", "./locales/");
     this.storageService = new ElectronStorageService(app.getPath("userData"));
-    this.stateService = new StateService(this.storageService, null, this.logService, null);
+    this.stateService = new StateService(
+      this.storageService,
+      null,
+      this.logService,
+      null,
+      true,
+      new AccountFactory(Account)
+    );
 
     this.windowMain = new WindowMain(
       this.stateService,

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -16,8 +16,8 @@ export class Account extends BaseAccount {
 
   constructor(init: Partial<Account>) {
     super(init);
-    this.directoryConfigurations = init.directoryConfigurations ?? new DirectoryConfigurations();
-    this.directorySettings = init.directorySettings ?? new DirectorySettings();
+    this.directoryConfigurations = init?.directoryConfigurations ?? new DirectoryConfigurations();
+    this.directorySettings = init?.directorySettings ?? new DirectorySettings();
   }
 }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -106,9 +106,7 @@ export class Program extends BaseProgram {
           this.main.stateService,
           this.main.cryptoService,
           this.main.policyService,
-          "connector",
-          this.main.loginSyncService,
-          this.main.keyConnectorService
+          "connector"
         );
 
         if (!Utils.isNullOrWhitespace(clientId)) {

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -575,10 +575,10 @@ export class StateService extends BaseStateService<Account> implements StateServ
   }
 
   protected resetAccount(account: Account) {
-    const persistentAccountInformation = { 
-        settings: account.settings,
-        directorySettings: account.directorySettings,
-        directoryConfigurations: account.directoryConfigurations 
+    const persistentAccountInformation = {
+      settings: account.settings,
+      directorySettings: account.directorySettings,
+      directoryConfigurations: account.directoryConfigurations,
     };
     return Object.assign(this.createAccount(), persistentAccountInformation);
   }

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -573,4 +573,13 @@ export class StateService extends BaseStateService<Account> implements StateServ
       (await this.storageService.has(keys.tempDirectoryConfigs))
     );
   }
+
+  protected resetAccount(account: Account) {
+    const persistentAccountInformation = { 
+        settings: account.settings,
+        directorySettings: account.directorySettings,
+        directoryConfigurations: account.directoryConfigurations 
+    };
+    return Object.assign(this.createAccount(), persistentAccountInformation);
+  }
 }

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -551,7 +551,11 @@ export class StateService extends BaseStateService<Account> implements StateServ
       await this.storageService.remove(keys.tempDirectoryConfigs);
     }
 
-    await this.saveAccount(account, await this.defaultOnDiskLocalOptions());
+    await this.storageService.save(
+      account.profile.userId,
+      account,
+      await this.defaultOnDiskLocalOptions()
+    );
   }
 
   protected async pushAccounts(): Promise<void> {

--- a/src/services/stateMigration.service.ts
+++ b/src/services/stateMigration.service.ts
@@ -1,6 +1,3 @@
-import { HtmlStorageLocation } from "jslib-common/enums/htmlStorageLocation";
-import { State } from "jslib-common/models/domain/state";
-
 import { StateMigrationService as BaseStateMigrationService } from "jslib-common/services/stateMigration.service";
 
 import { StateVersion } from "jslib-common/enums/stateVersion";
@@ -30,7 +27,6 @@ const SecureStorageKeys: { [key: string]: any } = {
 };
 
 const Keys: { [key: string]: any } = {
-  state: "state",
   entityId: "entityId",
   directoryType: "directoryType",
   organizationId: "organizationId",
@@ -39,6 +35,8 @@ const Keys: { [key: string]: any } = {
   lastSyncHash: "lastSyncHash",
   syncingDir: "syncingDir",
   syncConfig: "syncConfig",
+  tempDirectoryConfigs: "tempDirectoryConfigs",
+  tempDirectorySettings: "tempDirectorySettings",
 };
 
 const ClientKeys: { [key: string]: any } = {
@@ -50,8 +48,7 @@ const ClientKeys: { [key: string]: any } = {
 
 export class StateMigrationService extends BaseStateMigrationService {
   async migrate(): Promise<void> {
-    let currentStateVersion =
-      (await this.storageService.get<State<Account>>("state"))?.globals?.stateVersion ?? StateVersion.One;
+    let currentStateVersion = await this.getCurrentStateVersion();
     while (currentStateVersion < StateVersion.Latest) {
       switch (currentStateVersion) {
         case StateVersion.One:
@@ -80,73 +77,74 @@ export class StateMigrationService extends BaseStateMigrationService {
   }
 
   protected async migrateStateFrom1To2(useSecureStorageForSecrets: boolean = true): Promise<void> {
+    // Grabbing a couple of key settings before they get cleared by the base migration
+    const userId = await this.get<string>(Keys.entityId);
+    const clientId = await this.get<string>(ClientKeys.clientId);
+    const clientSecret = await this.get<string>(ClientKeys.clientSecret);
+
     await super.migrateStateFrom1To2();
-    const state = await this.storageService.get<State<Account>>(Keys.state);
-    const userId = await this.storageService.get<string>(Keys.entityId);
+    //
 
-    if (userId != null) {
-      state.accounts[userId] = new Account({
-        directorySettings: {
-          directoryType: await this.storageService.get<DirectoryType>(Keys.directoryType),
-          organizationId: await this.storageService.get<string>(Keys.organizationId),
-          lastUserSync: await this.storageService.get<Date>(Keys.lastUserSync),
-          lastGroupSync: await this.storageService.get<Date>(Keys.lastGroupSync),
-          lastSyncHash: await this.storageService.get<string>(Keys.lastSyncHash),
-          syncingDir: await this.storageService.get<boolean>(Keys.syncingDir),
-          sync: await this.storageService.get<SyncConfiguration>(Keys.syncConfig),
-        },
-        profile: {
-          entityId: await this.storageService.get<string>(Keys.entityId),
-        },
-        directoryConfigurations: new DirectoryConfigurations(),
-        clientKeys: {
-          clientId: await this.storageService.get<string>(ClientKeys.clientId),
-          clientSecret: await this.storageService.get<string>(ClientKeys.clientSecret),
-        },
-      });
-    }
-
-    for (const key in DirectoryType) {
-      if (await this.storageService.has(SecureStorageKeys.directoryConfigPrefix + key)) {
-        switch (+key) {
-          case DirectoryType.Ldap:
-            state.accounts[userId].directoryConfigurations.ldap =
-              await this.storageService.get<LdapConfiguration>(
-                SecureStorageKeys.directoryConfigPrefix + key
-              );
-            break;
-          case DirectoryType.GSuite:
-            state.accounts[userId].directoryConfigurations.gsuite =
-              await this.storageService.get<GSuiteConfiguration>(
-                SecureStorageKeys.directoryConfigPrefix + key
-              );
-            break;
-          case DirectoryType.AzureActiveDirectory:
-            state.accounts[userId].directoryConfigurations.azure =
-              await this.storageService.get<AzureConfiguration>(
-                SecureStorageKeys.directoryConfigPrefix + key
-              );
-            break;
-          case DirectoryType.Okta:
-            state.accounts[userId].directoryConfigurations.okta =
-              await this.storageService.get<OktaConfiguration>(
-                SecureStorageKeys.directoryConfigPrefix + key
-              );
-            break;
-          case DirectoryType.OneLogin:
-            state.accounts[userId].directoryConfigurations.oneLogin =
-              await this.storageService.get<OneLoginConfiguration>(
-                SecureStorageKeys.directoryConfigPrefix + key
-              );
-            break;
+    // Setup reusable method for clearing keys since we will want to do that regardless of if there is an active authenticated session
+    const clearDirectoryConnectorV1Keys = async () => {
+      for (const key in Keys) {
+        if (key == null) {
+          continue;
         }
-        await this.storageService.remove(SecureStorageKeys.directoryConfigPrefix + key);
+        for (const directoryType in DirectoryType) {
+          if (directoryType == null) {
+            continue;
+          }
+          await this.set(SecureStorageKeys.directoryConfigPrefix + directoryType, null);
+        }
       }
+    };
+    //
+
+    // Initilize typed objects from key/value pairs in storage to either be saved temporarily until an account is authed or applied to the active account
+    const getDirectoryConfig = async <T>(type: DirectoryType) =>
+      await this.get<T>(SecureStorageKeys.directoryConfigPrefix + type);
+    const directoryConfigs: DirectoryConfigurations = {
+      ldap: await getDirectoryConfig<LdapConfiguration>(DirectoryType.Ldap),
+      gsuite: await getDirectoryConfig<GSuiteConfiguration>(DirectoryType.GSuite),
+      azure: await getDirectoryConfig<AzureConfiguration>(DirectoryType.AzureActiveDirectory),
+      okta: await getDirectoryConfig<OktaConfiguration>(DirectoryType.Okta),
+      oneLogin: await getDirectoryConfig<OneLoginConfiguration>(DirectoryType.OneLogin),
+    };
+
+    const directorySettings: DirectorySettings = {
+      directoryType: await this.get<DirectoryType>(Keys.directoryType),
+      organizationId: await this.get<string>(Keys.organizationId),
+      lastUserSync: await this.get<Date>(Keys.lastUserSync),
+      lastGroupSync: await this.get<Date>(Keys.lastGroupSync),
+      lastSyncHash: await this.get<string>(Keys.lastSyncHash),
+      syncingDir: await this.get<boolean>(Keys.syncingDir),
+      sync: await this.get<SyncConfiguration>(Keys.syncConfig),
+    };
+    //
+
+    // (userId == null) = no authed account, stored data temporarily to be applied and cleared on next auth
+    // (userId != null) = authed account known, applied stored data to it and do not save temp data
+    if (userId == null) {
+      await this.set(Keys.tempDirectoryConfigs, directoryConfigs);
+      await this.set(Keys.tempDirectorySettings, directorySettings);
+      await clearDirectoryConnectorV1Keys();
+      return;
     }
 
-    state.globals.environmentUrls = await this.storageService.get("environmentUrls");
+    const account = await this.get<Account>(userId);
+    account.directoryConfigurations = directoryConfigs;
+    account.directorySettings = directorySettings;
+    account.profile = {
+      entityId: userId,
+    };
+    account.clientKeys = {
+      clientId: clientId,
+      clientSecret: clientSecret,
+    };
 
-    await this.storageService.save("state", state);
+    await this.set(userId, account);
+    await clearDirectoryConnectorV1Keys();
 
     if (useSecureStorageForSecrets) {
       for (const key in SecureStorageKeys) {

--- a/src/services/stateMigration.service.ts
+++ b/src/services/stateMigration.service.ts
@@ -83,7 +83,6 @@ export class StateMigrationService extends BaseStateMigrationService {
     const clientSecret = await this.get<string>(ClientKeys.clientSecret);
 
     await super.migrateStateFrom1To2();
-    //
 
     // Setup reusable method for clearing keys since we will want to do that regardless of if there is an active authenticated session
     const clearDirectoryConnectorV1Keys = async () => {
@@ -99,7 +98,6 @@ export class StateMigrationService extends BaseStateMigrationService {
         }
       }
     };
-    //
 
     // Initilize typed objects from key/value pairs in storage to either be saved temporarily until an account is authed or applied to the active account
     const getDirectoryConfig = async <T>(type: DirectoryType) =>
@@ -121,7 +119,6 @@ export class StateMigrationService extends BaseStateMigrationService {
       syncingDir: await this.get<boolean>(Keys.syncingDir),
       sync: await this.get<SyncConfiguration>(Keys.syncConfig),
     };
-    //
 
     // (userId == null) = no authed account, stored data temporarily to be applied and cleared on next auth
     // (userId != null) = authed account known, applied stored data to it and do not save temp data

--- a/src/services/stateMigration.service.ts
+++ b/src/services/stateMigration.service.ts
@@ -136,7 +136,9 @@ export class StateMigrationService extends BaseStateMigrationService {
     account.directoryConfigurations = directoryConfigs;
     account.directorySettings = directorySettings;
     account.profile = {
+      userId: userId,
       entityId: userId,
+      apiKeyClientId: clientId,
     };
     account.clientKeys = {
       clientId: clientId,


### PR DESCRIPTION
## Relevant work
* Duplicate PR: https://github.com/bitwarden/directory-connector/pull/211
* jslib update to storage schema: https://github.com/bitwarden/jslib/pull/611
  * This PR split the "state" object in storage up into several top level account keys, a globals key, and an authenticatedAccounts key.
* jslib update to ensure data is properly migrated when there isn't an actively logged in account: https://github.com/bitwarden/jslib/pull/615
  * This PR checked for a userId in storage, and if one isn't found saves all settings to a temporary key that are applied to the next authenticated account before being cleared.
* jslib update to fix key connector issues https://github.com/bitwarden/jslib/pull/616/files

## Type of change

- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Essentially this is just a jslib update for the directory connector. 

Some changes needed to be made to account for recent key connector changes. 

Some other changes needed to be made to adopt the new storage structure passed down from the base jslib State service.

## Code changes
* Updated jslib
* Added logic to the StateMigrationService and StateService for managing temporary storage of settings and directory configurations if an active account isn't found.
* Restructured StateMigrationService and StateService logic to work with accounts as top level items without a parent "state" key.
* Removed LoginCommand params that were removed from jslib recently
* Added the AccountFactory param needed for the StateService to create accounts.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
