### PR TITLE
[bug] Remove redundant state clean call

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -66,10 +66,6 @@ export class AuthService extends AuthServiceBase {
     return await super.logInApiKey(clientId, clientSecret);
   }
 
-  async logOut(callback: Function) {
-    super.logOut(callback);
-  }
-
   private async organizationLogInHelper(clientId: string, clientSecret: string) {
     const appId = await this.appIdService.getAppId();
     const entityId = clientId.split("organization.")[1];

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -67,7 +67,6 @@ export class AuthService extends AuthServiceBase {
   }
 
   async logOut(callback: Function) {
-    this.stateService.clean();
     super.logOut(callback);
   }
 


### PR DESCRIPTION
https://app.asana.com/0/1201648796371593/1201694099230961

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Bug
When logging out the process succeeds, but an error is logged to the console about not being able to clear tokens. 

## Code changes
* We are redundantly cleaning state twice right now, once in the [main logout function](https://github.com/bitwarden/directory-connector/blob/9e3d1caee4c8f986fb6acff0cff7fc2375c53491/src/bwdc.ts#L262-L265), and once in the DC extended auth service. This is resulting in the method being called twice for logouts, and the second time throws an error because it expects to have something to clean up. I removed the auth service call, though I think removing either would have the same effect.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
