### PR TITLE
[Icons] FF - old font cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
         "electron-notarize": "^1.1.1",
         "electron-rebuild": "^3.2.5",
         "electron-reload": "^1.5.0",
-        "font-awesome": "4.7.0",
         "html-loader": "^3.0.1",
         "html-webpack-plugin": "^5.5.0",
         "husky": "^7.0.4",
@@ -4527,15 +4526,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.3"
       }
     },
     "node_modules/forcefocus": {
@@ -14156,12 +14146,6 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
-    },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
-      "dev": true
     },
     "forcefocus": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "electron-notarize": "^1.1.1",
     "electron-rebuild": "^3.2.5",
     "electron-reload": "^1.5.0",
-    "font-awesome": "4.7.0",
     "html-loader": "^3.0.1",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^7.0.4",

--- a/webpack.renderer.js
+++ b/webpack.renderer.js
@@ -20,7 +20,7 @@ const common = {
       },
       {
         test: /\.(jpe?g|png|gif|svg)$/i,
-        exclude: /.*(fontawesome-webfont)\.svg/,
+        exclude: /.*(bwi-font)\.svg/,
         generator: {
           filename: "images/[name][ext]",
         },


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Remove all instances of `FA`. Merge to both `master` and `rc` once approved.

## Code changes
- **package.json**: Removed `FA` node module from the web application
- **package-lock.json**: Updated due to `package.json` changes
- **webpack.renderer.js**: Exclude `bwi-font` instead of `FA`

## Testing requirements
-  Make sure the components listed above are working/looking as expected

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
