### PR TITLE
Fix group only sync errors for AD

### DIFF
--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -137,6 +137,10 @@ export class SyncService {
   }
 
   private removeDuplicateUsers(users: UserEntry[]) {
+    if (users == null) {
+      return null;
+    }
+
     const uniqueUsers = new Array<UserEntry>();
     const processedActiveUsers = new Map<string, string>();
     const processedDeletedUsers = new Map<string, string>();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix errors when syncing groups only for AD and Azure AD
[Ticket](https://app.asana.com/0/1169444489336079/1201188029307148)

## Code changes

- **src/services/sync.service.ts:** Add a null check in `removeDuplicateUsers()`. When users were iterated over, an exception would get thrown if users was null which will always happen when only syncing groups. This was previously a call to reduce(), which is why the original error was "Cannot read property 'reduce' of null" and is now "Cannot read properties of null (reading 'foreach')".

## Testing requirements

Ensure that syncing only groups works as intended for AD and Azure AD.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
