### PR TITLE
Use saveAccount to scaffold new account

### DIFF
--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -529,12 +529,12 @@ export class StateService
   }
 
   protected async scaffoldNewAccountDiskStorage(account: Account): Promise<void> {
-    const storedAccount = await this.getAccount(
-      this.reconcileOptions(
-        { userId: account.profile.userId },
-        await this.defaultOnDiskLocalOptions()
-      )
+    const storageOptions = this.reconcileOptions(
+      { userId: account.profile.userId },
+      await this.defaultOnDiskLocalOptions()
     );
+
+    const storedAccount = await this.getAccount(storageOptions);
     if (storedAccount != null) {
       account.settings = storedAccount.settings;
       account.directorySettings = storedAccount.directorySettings;
@@ -551,11 +551,7 @@ export class StateService
       await this.storageService.remove(keys.tempDirectoryConfigs);
     }
 
-    await this.storageService.save(
-      account.profile.userId,
-      account,
-      await this.defaultOnDiskLocalOptions()
-    );
+    await this.saveAccount(account, storageOptions);
   }
 
   protected async pushAccounts(): Promise<void> {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the following defect: when upgrading from the current release of d-c, logging in fails silently.

Asana: https://app.asana.com/0/1169444489336079/1201909137219813/f

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories--> 

d-c has its own account scaffolding method in `scaffoldNewAccountDiskStorage`, but it was calling `storageService.save` directly instead of using `saveAccount` in the base class. You must use `saveAccount`, because that deals with any stale disk cache (see https://github.com/bitwarden/jslib/pull/668). Otherwise, it writes the new value to disk but does not clear the old disk cache, and `stateService` methods continue reading the old cached values.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Regression testing on logging in:
* after upgrading
* on a fresh install (or after clearing data.json)
* in the gui and cli

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
