### PR TITLE
Move delta tokens out of secure storage

### DIFF
--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -238,50 +238,6 @@ export class StateService
     );
   }
 
-  async getUserDelta(options?: StorageOptions): Promise<string> {
-    options = this.reconcileOptions(options, await this.defaultSecureStorageOptions());
-    if (options?.userId == null) {
-      return null;
-    }
-    return await this.secureStorageService.get<string>(
-      `${options.userId}_${SecureStorageKeys.userDelta}`
-    );
-  }
-
-  async setUserDelta(value: string, options?: StorageOptions): Promise<void> {
-    options = this.reconcileOptions(options, await this.defaultSecureStorageOptions());
-    if (options?.userId == null) {
-      return;
-    }
-    await this.secureStorageService.save(
-      `${options.userId}_${SecureStorageKeys.userDelta}`,
-      value,
-      options
-    );
-  }
-
-  async getGroupDelta(options?: StorageOptions): Promise<string> {
-    options = this.reconcileOptions(options, await this.defaultSecureStorageOptions());
-    if (options?.userId == null) {
-      return null;
-    }
-    return await this.secureStorageService.get<string>(
-      `${options.userId}_${SecureStorageKeys.groupDelta}`
-    );
-  }
-
-  async setGroupDelta(value: string, options?: StorageOptions): Promise<void> {
-    options = this.reconcileOptions(options, await this.defaultSecureStorageOptions());
-    if (options?.userId == null) {
-      return;
-    }
-    await this.secureStorageService.save(
-      `${options.userId}_${SecureStorageKeys.groupDelta}`,
-      value,
-      options
-    );
-  }
-
   async getConfiguration(type: DirectoryType): Promise<IConfiguration> {
     switch (type) {
       case DirectoryType.Ldap:
@@ -512,6 +468,40 @@ export class StateService
     );
     account.directorySettings.syncingDir = value;
     await this.saveAccount(account, this.reconcileOptions(options, this.defaultInMemoryOptions));
+  }
+
+  async getUserDelta(options?: StorageOptions): Promise<string> {
+    return (
+      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
+    )?.directorySettings?.userDelta;
+  }
+
+  async setUserDelta(value: string, options?: StorageOptions): Promise<void> {
+    const account = await this.getAccount(
+      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+    );
+    account.directorySettings.userDelta = value;
+    await this.saveAccount(
+      account,
+      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+    );
+  }
+
+  async getGroupDelta(options?: StorageOptions): Promise<string> {
+    return (
+      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
+    )?.directorySettings?.groupDelta;
+  }
+
+  async setGroupDelta(value: string, options?: StorageOptions): Promise<void> {
+    const account = await this.getAccount(
+      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+    );
+    account.directorySettings.groupDelta = value;
+    await this.saveAccount(
+      account,
+      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+    );
   }
 
   async clearSyncSettings(hashToo = false) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Syncing with the BWDC CLI on Windows was crashing.
https://app.asana.com/0/1201211497354246/1201885120581283

It was happening because the user and group deltas were previously stored in regular storage, not secure storage.
 
When we did the state service swap out, we accidentally put them in secure storage instead of regular storage. This worked fine on MacOS because keychain has a pretty large storage limit (4KB), but Windows credential manager has a much smaller limit (256 characters) and the value is exceeding it by a lot (about 3,500 characters, or 3.7KB). It also fails to save in the desktop app on Windows, but does so silently hence it wasn't causing the user to see it from what I can tell (the value is not stored at all in credential manager). We do not have control over the size of this delta as far as I could determine, it's something coming from Azure.

I'm going to move these value back to regular storage. This will be a simple change but we'll need to add a migration to the BWDC state migrator as well.

## Code changes

- **src/services/state.service.ts:** Redo old state service functions to get and save these deltas from regular storage (data.json) like they were before.
- **src/services/stateMigration.service.ts:** Add a migration to move these keys from secure storage to regular storage. This will probably only effect MacOS clients. Also fix previous migration for those that haven't migrated yet.

## Testing requirements

Test Azure DevOps syncing functionality and make sure that the CLI sync succeeds and that userDelta is now being saved in `data.json`.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
