### PR TITLE
[EC-176] Fix CLI errors caused by server URLs

### DIFF
--- a/src/abstractions/state.service.ts
+++ b/src/abstractions/state.service.ts
@@ -63,4 +63,5 @@ export abstract class StateService extends BaseStateServiceAbstraction<Account> 
   getSyncingDir: (options?: StorageOptions) => Promise<boolean>;
   setSyncingDir: (value: boolean, options?: StorageOptions) => Promise<void>;
   clearSyncSettings: (syncHashToo: boolean) => Promise<void>;
+  setSecureSecrets: () => Promise<void>;
 }

--- a/src/app/tabs/settings.component.ts
+++ b/src/app/tabs/settings.component.ts
@@ -77,6 +77,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     if (this.ldap != null && this.ldap.ad) {
       this.ldap.pagedSearch = true;
     }
+    await this.stateService.setSecureSecrets();
     await this.stateService.setDirectoryType(this.directory);
     await this.stateService.setDirectory(DirectoryType.Ldap, this.ldap);
     await this.stateService.setDirectory(DirectoryType.GSuite, this.gsuite);

--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -141,6 +141,7 @@ export class ConfigCommand {
 
   private async saveConfig() {
     ConnectorUtils.adjustConfigForSave(this.ldap, this.sync);
+    await this.stateService.setSecureSecrets();
     await this.stateService.setDirectoryType(this.directory);
     await this.stateService.setDirectory(DirectoryType.Ldap, this.ldap);
     await this.stateService.setDirectory(DirectoryType.GSuite, this.gsuite);

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -2,6 +2,7 @@ import { LogService } from "jslib-common/abstractions/log.service";
 import { StateMigrationService } from "jslib-common/abstractions/stateMigration.service";
 import { StorageService } from "jslib-common/abstractions/storage.service";
 import { StateFactory } from "jslib-common/factories/stateFactory";
+import { EnvironmentUrls } from "jslib-common/models/domain/environmentUrls";
 import { GlobalState } from "jslib-common/models/domain/globalState";
 import { StorageOptions } from "jslib-common/models/domain/storageOptions";
 import { StateService as BaseStateService } from "jslib-common/services/state.service";
@@ -606,5 +607,9 @@ export class StateService
       directoryConfigurations: account.directoryConfigurations,
     };
     return Object.assign(this.createAccount(), persistentAccountInformation);
+  }
+
+  async getEnvironmentUrls(options?: StorageOptions): Promise<EnvironmentUrls> {
+    return await this.getGlobalEnvironmentUrls(options);
   }
 }

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -55,7 +55,6 @@ export class StateService
   }
 
   async saveAccountToDisk(account: Account, options: StorageOptions): Promise<void> {
-    await this.setSecureSecrets(account.directoryConfigurations);
     const accountNoSecrets = this.removeSecrets(account);
     return super.saveAccountToDisk(accountNoSecrets, options);
   }
@@ -83,7 +82,11 @@ export class StateService
     return account;
   }
 
-  private async setSecureSecrets(config: DirectoryConfigurations) {
+  async setSecureSecrets() {
+    const config = (
+      await this.getAccount(this.reconcileOptions({}, await this.defaultOnDiskOptions()))
+    )?.directoryConfigurations;
+
     if (this.useSecureStorageForSecrets) {
       if (config.azure != null && config.azure.key != StoredSecurely) {
         await this.setAzureKey(config.azure.key);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

[Context](https://bitwarden.atlassian.net/browse/EC-176)
Fixes syncing from the CLI would throw the error `Cannot read properties of null (reading 'directorySettings')` for some users. Determined that this was happening for people with server url's configured and that the CLI was getting the base url on the account level. We are never going to utilize separate accounts in the Directory Connector, override stateService.getEnvironmentUrls to only return the global ones. 

Also a refactor to `stateService` for how we handle saving the account, given that d-c is a bit different to the other clients.

## Testing requirements
See linked ticket
## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
