### PR TITLE
[EC-176] Fix CLI errors caused by server URLs

### DIFF
--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -2,6 +2,7 @@ import { LogService } from "jslib-common/abstractions/log.service";
 import { StateMigrationService } from "jslib-common/abstractions/stateMigration.service";
 import { StorageService } from "jslib-common/abstractions/storage.service";
 import { StateFactory } from "jslib-common/factories/stateFactory";
+import { EnvironmentUrls } from "jslib-common/models/domain/environmentUrls";
 import { GlobalState } from "jslib-common/models/domain/globalState";
 import { StorageOptions } from "jslib-common/models/domain/storageOptions";
 import { StateService as BaseStateService } from "jslib-common/services/state.service";
@@ -567,5 +568,9 @@ export class StateService
       directoryConfigurations: account.directoryConfigurations,
     };
     return Object.assign(this.createAccount(), persistentAccountInformation);
+  }
+
+  async getEnvironmentUrls(options?: StorageOptions): Promise<EnvironmentUrls> {
+    return await this.getGlobalEnvironmentUrls(options);
   }
 }

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -571,6 +571,6 @@ export class StateService
   }
 
   async getEnvironmentUrls(options?: StorageOptions): Promise<EnvironmentUrls> {
-    return await this.getGlobalEnvironmentUrls(options);
+    return this.getGlobalEnvironmentUrls(options);
   }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

[Context](https://bitwarden.atlassian.net/browse/EC-176)
Fixes syncing from the CLI would throw the error Cannot read properties of null (reading 'directorySettings') for some users. Determined that this was happening for people with server url's configured and that the CLI was getting the base url on the account level. We are never going to utilize separate accounts in the Directory Connector, override stateService.getEnvironmentUrls to only return the global ones.

## Code changes

- **src/services/state.service.ts:** Override state service to only use global environment urls

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
