### PR TITLE
Update example after LDAP library syntax change

### DIFF
--- a/src/app/tabs/settings.component.html
+++ b/src/app/tabs/settings.component.html
@@ -700,7 +700,7 @@
               [(ngModel)]="sync.groupFilter"
             ></textarea>
             <small class="text-muted form-text" *ngIf="directory === directoryType.Ldap"
-              >{{ "ex" | i18n }} (&amp;!(name=Sales*)!(name=IT*))</small
+              >{{ "ex" | i18n }} (&amp;(objectClass=group)(!(cn=Sales*))(!(cn=IT*)))</small
             >
             <small
               class="text-muted form-text"


### PR DESCRIPTION
The in-app example is no longer valid after an upstream LDAP library change; updating the example with the correct syntax

## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

Provide a valid example for Group Filter on AD/LDAP in the GUI

## Code changes

- **settings.component.html:** Update example text

## Testing requirements

None

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
