### PR TITLE
If a group name is too long, shorten it to 100 characters

### DIFF
--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -415,7 +415,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
     const entry = new GroupEntry();
     entry.referenceId = group.id;
     entry.externalId = group.id;
-    entry.name = group.displayName;
+    entry.name = group.displayName.substring(0, 100);
 
     const memReq = this.client.api("/groups/" + group.id + "/members");
     let memRes = await memReq.get();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When a group originating from Azure AD has more than 100 characters in its name, the entire import will fail. This PR shortens every group name to the maximum of 100 characters to make sure the import passes.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **[src/services/azure-directory.service.ts](https://github.com/bitwarden/directory-connector/compare/master...hajekj:bitwarden-directory-connector:master#diff-5c4d3a318b5b741e68fb8fe5a8502732572ce3bbffb84cd5f5137ddf7779476c):** Shorten the display name to 100 characters,

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

N/A, bugfix.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
