### PR TITLE
[PS-1212] GSuite: Use custom filter query when fetching groups.

### DIFF
--- a/src/services/gsuite-directory.service.ts
+++ b/src/services/gsuite-directory.service.ts
@@ -151,12 +151,13 @@ export class GSuiteDirectoryService extends BaseDirectoryService implements IDir
     users: UserEntry[]
   ): Promise<GroupEntry[]> {
     const entries: GroupEntry[] = [];
+    const query = this.createDirectoryQuery(this.syncConfig.groupFilter);
     let nextPageToken: string = null;
 
     // eslint-disable-next-line
     while (true) {
       this.logService.info("Querying groups - nextPageToken:" + nextPageToken);
-      const p = Object.assign({ pageToken: nextPageToken }, this.authParams);
+      const p = Object.assign({ query: query, pageToken: nextPageToken }, this.authParams);
       const res = await this.service.groups.list(p);
       if (res.status !== 200) {
         throw new Error("Group list API failed: " + res.statusText);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Custom SDK query is used when filtering users, but not groups. This add the feature to groups as well.
It was either forgotten or maybe wasn't available at that time.

Docs will need to update to include the custom query for groups.

## Code changes
The change reuses code for filtering users and applies it for groups as well.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [x] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
