### PR TITLE
[PS-1213] GSuite: Preflat groups using includeDerivedMembership flag.

### DIFF
--- a/src/services/gsuite-directory.service.ts
+++ b/src/services/gsuite-directory.service.ts
@@ -190,7 +190,10 @@ export class GSuiteDirectoryService extends BaseDirectoryService implements IDir
 
     // eslint-disable-next-line
     while (true) {
-      const p = Object.assign({ groupKey: group.id, pageToken: nextPageToken }, this.authParams);
+      const p = Object.assign(
+        { groupKey: group.id, includeDerivedMembership: true, pageToken: nextPageToken },
+        this.authParams
+      );
       const memRes = await this.service.members.list(p);
       if (memRes.status !== 200) {
         this.logService.warning("Group member list API failed: " + memRes.statusText);
@@ -209,8 +212,6 @@ export class GSuiteDirectoryService extends BaseDirectoryService implements IDir
               continue;
             }
             entry.userMemberExternalIds.add(member.id);
-          } else if (type === "group") {
-            entry.groupMemberReferenceIds.add(member.id);
           } else if (type === "customer") {
             for (const user of users) {
               entry.userMemberExternalIds.add(user.externalId);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Since Bitwarden doesn't have nested groups the function `flattenUsersToGroups` is used to flatten nested groups into one list of users. GSuite SDK supports `includeDerivedMembership` which already pre-flattens the user list while fetching if from the GSuite API. (It also returns all intermediate groups, but at that point we can safely ignore them.)

The motivation is that if we ignore some intermediate groups (because we don't want them in BW) the flattening function cannot fetch members of that group. So either we have to include all intermediate groups or we won't get all nested users.

### Example:
GSuite group "BW Admins" has one member group "GS Admins".
GSuite group "GS Admins" has one member account "admin@company.org".

I want to import group "BW Admins" with one member "admin@company.org".
Currently I need to import also the group "GS Admins", otherwise this tool doesn't resolve members of the intermediate group (because it is excluded).

### Potential breaking change?
This might be breaking, because someone might be relying on the exclusion of the intermediate groups, but I think this is more a bug than a feature.
If it is breaking I can also introduce new sync config option to have it as opt-in.


## Code changes

I've added `includeDerivedMembership: true` parameter to member.list GSuite SDK call, which does flattening of nested groups in GSuite rather than in the code.
Also we can safely ignore all groups return by this call, since it is only used for nested group flattening.
https://developers.google.com/admin-sdk/directory/reference/rest/v1/members/list#query-parameters

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
