### PR TITLE
[EC-488] Handle falsy values in keytarSecureStorageService

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
 
       - name: Version Test
         run: |
+          sudo apt-get update
           sudo apt install libsecret-1-0 dbus-x11 gnome-keyring
           eval $(dbus-launch --sh-syntax)
 

--- a/src/services/keytarSecureStorage.service.ts
+++ b/src/services/keytarSecureStorage.service.ts
@@ -16,6 +16,12 @@ export class KeytarSecureStorageService implements StorageService {
   }
 
   save(key: string, obj: any): Promise<any> {
+    // keytar throws if you try to save a falsy value: https://github.com/atom/node-keytar/issues/86
+    // handle this by removing the key instead
+    if (!obj) {
+      return this.remove(key);
+    }
+
     return setPassword(this.serviceName, key, JSON.stringify(obj));
   }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the following bug:

1. log in to bwdc CLI
2. run `bwdc config directory 0`
3. observe error: `Password is required.`

This error is being thrown by keytar - "Password" is referring to the secret being saved in the keychain (not the user's password/api key).

Keytar throws if you try to save a falsy value. The config command basically loads and then re-saves all config settings, so any secrets that aren't explicitly set will be saved to the keychain as null values, triggering this error.

This was introduced with account switching. Before that, `setDirectory` checked for `null` and would call `secureStorageService.remove` instead. That check was removed.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **src/services/keytarSecureStorage.service.ts** - check for null and call `remove` instead. By implementing it here we avoid this problem regardless of the caller, and this method can never be validly called with a null value anyway.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
