### PR TITLE
[EC-682] Adjust group query assignment

### DIFF
--- a/src/services/gsuite-directory.service.ts
+++ b/src/services/gsuite-directory.service.ts
@@ -157,7 +157,12 @@ export class GSuiteDirectoryService extends BaseDirectoryService implements IDir
     // eslint-disable-next-line
     while (true) {
       this.logService.info("Querying groups - nextPageToken:" + nextPageToken);
-      const p = Object.assign({ query: query, pageToken: nextPageToken }, this.authParams);
+      let p = null;
+      if (query == null) {
+        p = Object.assign({ pageToken: nextPageToken }, this.authParams);
+      } else {
+        p = Object.assign({ query: query, pageToken: nextPageToken }, this.authParams);
+      }
       const res = await this.service.groups.list(p);
       if (res.status !== 200) {
         throw new Error("Group list API failed: " + res.statusText);


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> For reasons unknown, empty query strings return a `400` for the `groups.list` Gsuite Directory API call. Therefore, in order to prevent issues retrieving groups, the API object is created and assigned a query **only if** the `query` is non-null

## Code changes
- **gsuite-directory.service.ts**: Separated `query` assignment into conditional statement

## Testing requirements
- Try standard `include/exclude` keywords for the `group filter`
- Try querying for a specific name `|name='Engineering'`
- Try both examples together
- Try an empty `group filter`

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
