### PR TITLE
[GSuite] Resolve conflicts using timestamps

### DIFF
--- a/src/models/userEntry.ts
+++ b/src/models/userEntry.ts
@@ -4,6 +4,8 @@ export class UserEntry extends Entry {
   email: string;
   disabled = false;
   deleted = false;
+  creationDate: Date = null;
+  deletionDate: Date = null;
 
   get displayName(): string {
     if (this.email == null) {
@@ -11,5 +13,19 @@ export class UserEntry extends Entry {
     }
 
     return this.email;
+  }
+
+  get relevantDate(): Date {
+    if (this.deleted) {
+      return this.deletionDate;
+    }
+    return this.creationDate;
+  }
+
+  newerThan(other: UserEntry): boolean {
+    if (this.relevantDate != null && other.relevantDate != null) {
+      return this.relevantDate > other.relevantDate;
+    }
+    return false;
   }
 }

--- a/src/services/gsuite-directory.service.ts
+++ b/src/services/gsuite-directory.service.ts
@@ -143,6 +143,8 @@ export class GSuiteDirectoryService extends BaseDirectoryService implements IDir
     entry.email = user.primaryEmail != null ? user.primaryEmail.trim().toLowerCase() : null;
     entry.disabled = user.suspended || false;
     entry.deleted = deleted;
+    entry.creationDate = user.creationTime != null ? new Date(user.creationTime) : null;
+    entry.deletionDate = user.deletionTime != null ? new Date(user.deletionTime) : null;
     return entry;
   }
 


### PR DESCRIPTION
When we check for duplicate emails, it's entirely possible that there are valid instances of this (e.g. a user has been repeatedly created and deleted, and finally created anew).

This changeset introduces the timestamp data provided by GSuite (specifically creation and deletion date), and applies the following heuristics:
- if a user was deleted before another one with the same Email address was created, then it can be ignored, and no duplicate email error need be raised
- if multiple users with the same email address were all deleted, we can safely synchronize that deletion.
- if a user has been deleted after the creation of a user with a conflicting email address, we still raise a duplicate email error.

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

We currently cannot synchronize our Google Workspace with Bitwarden, because the duplicate detection chokes on one (or more?) users that have been repeatedly created, deleted, and recreated again.  

## Code changes

- **src/models/userEntry.ts** - add fields for creationDate and deletionDate, an accessor for whichever of these is more relevant, and a newerThan(other) method to help with the sorting of duplicate email users.
- **src/services/gsuite-directory.service.ts** - populate the new fields when synchronizing from Google Suite
- **src/services/sync.service.ts** - rework the duplicate detection heuristics.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
