### PR TITLE
Upgrade typescript-transform-paths (v2.2.4 ⮕ v3.4.6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "ts-loader": "9.5.1",
         "tsconfig-paths-webpack-plugin": "4.1.0",
         "typescript": "4.9.5",
-        "typescript-transform-paths": "2.2.4",
+        "typescript-transform-paths": "3.4.6",
         "webpack": "5.89.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0",
@@ -20453,9 +20453,9 @@
       }
     },
     "node_modules/typescript-transform-paths": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-2.2.4.tgz",
-      "integrity": "sha512-i+/sgp3rw1ZronMCm2TKGBy1dlvN88Kd8CCb+HWnOE8+Hv0uIVnbC8xM5AD2t1JBCWabEhuH9p3n8DOVi0+R6g==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.4.6.tgz",
+      "integrity": "sha512-qdgpCk9oRHkIBhznxaHAapCFapJt5e4FbFik7Y4qdqtp6VyC3smAIPoDEIkjZ2eiF7x5+QxUPYNwJAtw0thsTw==",
       "dev": true,
       "dependencies": {
         "minimatch": "^3.0.4"

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "ts-loader": "9.5.1",
     "tsconfig-paths-webpack-plugin": "4.1.0",
     "typescript": "4.9.5",
-    "typescript-transform-paths": "2.2.4",
+    "typescript-transform-paths": "3.4.6",
     "webpack": "5.89.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0",


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

As part of a dependency audit of the project this PR updates `typescript-transform-paths` to `v3.4.6`

There are no breaking changes in this upgrade

## Code changes

* Upgrade version in `package.json`
* Rebuild `package-lock.json`