### PR TITLE
Throw an error if the gsuite member query fails

### DIFF
--- a/src/services/gsuite-directory.service.ts
+++ b/src/services/gsuite-directory.service.ts
@@ -199,8 +199,7 @@ export class GSuiteDirectoryService extends BaseDirectoryService implements IDir
       const p = Object.assign({ groupKey: group.id, pageToken: nextPageToken }, this.authParams);
       const memRes = await this.service.members.list(p);
       if (memRes.status !== 200) {
-        this.logService.warning("Group member list API failed: " + memRes.statusText);
-        return entry;
+        throw new Error("Group member list API failed: " + memRes.statusText);
       }
 
       nextPageToken = memRes.data.nextPageToken;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-1716

## 📔 Objective

Some customers report sporadic and non-identifiable errors syncing from gsuite that result in full directory wipes.

This is a risk when using the override setting, but is an issue that could be handled better in this case by directory connector.

This PR adjusts the gsuite service to throw an error if the member search endpoint throws. This lines up with the way we handle all other queries in this service, and from testing does not appear to break syncing in any other ways.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
