### PR TITLE
Use latest Renovate config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,10 +6,3 @@
 
 # Default file owners.
 * @bitwarden/team-admin-console-dev
-
-# DevOps for Actions and other workflow changes.
-.github/workflows @bitwarden/dept-devops
-.github/secrets @bitwarden/dept-devops
-
-# Multiple Owners
-**/package.json

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,31 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    "github>bitwarden/renovate-config:pin-actions",
-    ":combinePatchMinorReleases",
-    ":dependencyDashboard",
-    ":maintainLockFilesWeekly",
-    ":pinAllExceptPeerDependencies",
-    ":prConcurrentLimit10",
-    ":rebaseStalePrs",
-    ":separateMajorReleases",
-    "group:monorepos",
-    "schedule:weekends"
-  ],
+  "extends": ["github>bitwarden/renovate-config"],
   "enabledManagers": ["github-actions", "npm"],
-  "commitMessagePrefix": "[deps]:",
-  "commitMessageTopic": "{{depName}}",
   "packageRules": [
+    {
+      "groupName": "gh minor",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
     {
       "groupName": "npm minor",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "matchFileNames": ["package.json"],
-      "description": "Admin Console owns general dependencies",
-      "reviewers": ["team:team-admin-console-dev"]
     }
   ]
 }


### PR DESCRIPTION
## Objective

Uses our standard Renovate configuration, with corresponding ownership so that these get more noticed.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
