### PR TITLE
BRE-264 - Update build workflow to use API key for App Store Connect

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -576,12 +576,20 @@ jobs:
 
       - name: Install Node dependencies
         run: npm install
+      
+      - name: Set up private auth key
+        run: |
+          mkdir ~/private_keys
+          cat << EOF > ~/private_keys/AuthKey_UFD296548T.p8
+          ${{ secrets.APP_STORE_CONNECT_AUTH_KEY }}
+          EOF
 
       - name: Build application
         run: npm run dist:mac
         env:
-          APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APP_STORE_CONNECT_TEAM_ISSUER: ${{ secrets.APP_STORE_CONNECT_TEAM_ISSUER }}
+          APP_STORE_CONNECT_AUTH_KEY: UFD296548T
+          APP_STORE_CONNECT_AUTH_KEY_PATH: ~/private_keys/AuthKey_UFD296548T.p8
           CSC_FOR_PULL_REQUEST: true
 
       - name: Upload .zip artifact

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -7,15 +7,30 @@ exports.default = async function notarizing(context) {
   if (electronPlatformName !== "darwin") {
     return;
   }
-  const appleId = process.env.APPLE_ID_USERNAME || process.env.APPLEID;
-  const appleIdPassword = process.env.APPLE_ID_PASSWORD || `@keychain:AC_PASSWORD`;
+
   const appName = context.packager.appInfo.productFilename;
-  return await notarize({
-    tool: "notarytool",
-    appBundleId: "com.bitwarden.directory-connector",
-    appPath: `${appOutDir}/${appName}.app`,
-    teamId: "LTZ2PFU5D6",
-    appleId: appleId,
-    appleIdPassword: appleIdPassword,
-  });
+  if (process.env.APP_STORE_CONNECT_TEAM_ISSUER) {
+    const appleApiIssuer = process.env.APP_STORE_CONNECT_TEAM_ISSUER;
+    const appleApiKey = process.env.APP_STORE_CONNECT_AUTH_KEY_PATH;
+    const appleApiKeyId = process.env.APP_STORE_CONNECT_AUTH_KEY;
+    return await notarize({
+      tool: "notarytool",
+      appBundleId: "com.bitwarden.directory-connector",
+      appPath: `${appOutDir}/${appName}.app`,
+      appleApiIssuer: appleApiIssuer,
+      appleApiKey: appleApiKey,
+      appleApiKeyId: appleApiKeyId,
+    });
+  } else {
+    const appleId = process.env.APPLE_ID_USERNAME || process.env.APPLEID;
+    const appleIdPassword = process.env.APPLE_ID_PASSWORD || `@keychain:AC_PASSWORD`;
+    return await notarize({
+      tool: "notarytool",
+      appBundleId: "com.bitwarden.directory-connector",
+      appPath: `${appOutDir}/${appName}.app`,
+      teamId: "LTZ2PFU5D6",
+      appleId: appleId,
+      appleIdPassword: appleIdPassword,
+    });
+  }
 };


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
- [Card](https://bitwarden.atlassian.net/browse/BRE-264?atlOrigin=eyJpIjoiMTQ1YWRiODI0YzY3NDUxNzhlNDRmNzY3NDM3NzMxY2YiLCJwIjoiaiJ9)

This PR update the `build` workflow to use an API key for App Store Connect.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/build.yml:** Add setup for private auth key and update environment variables for building application
- **scripts/notarize.js:** Update logic to use API key if environment variables are set.
