### PR TITLE
Remove npm minor grouping from renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,16 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config"],
-  "enabledManagers": ["github-actions", "npm"],
+  "enabledManagers": ["github-actions"],
   "packageRules": [
     {
       "groupName": "gh minor",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "groupName": "npm minor",
-      "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"]
     }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config"],
-  "enabledManagers": ["github-actions"],
+  "enabledManagers": ["github-actions", "npm"],
   "packageRules": [
     {
       "groupName": "gh minor",


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The renovate config in this repository groups patch and minor updates together. I think this is unhelpful as it has led to this enormous PR (which is failing): https://github.com/bitwarden/directory-connector/pull/353.

I'd rather smaller, easier PRs, even if we have many of them. We don't use this grouping in `clients` either.

The proposal here is to remove this grouping (this PR) and then force renovate to create new update PRs for each dependency (not sure how to do this - @withinfocus?).

@withinfocus renovate is your area, do you have any feedback on this approach? 

@bitwarden/team-admin-console-dev this is going to affect the team, so feedback welcome.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
