### PR TITLE
[PM-16412] Remove typescript-transform-paths dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,6 @@
         "tsconfig-paths-webpack-plugin": "4.2.0",
         "type-fest": "4.32.0",
         "typescript": "5.4.5",
-        "typescript-transform-paths": "3.5.2",
         "webpack": "5.97.1",
         "webpack-cli": "5.1.4",
         "webpack-merge": "6.0.1",
@@ -21611,35 +21610,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/typescript-transform-paths": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.5.2.tgz",
-      "integrity": "sha512-IRDVXfU7oscLwTvLabXprFrFCMUdBJbdUDtxbHFEsau9FlqrrdgS8PfwUltKDAh75vJFkQ8QdXAt/nzIWWp+fA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^9.0.5"
-      },
-      "peerDependencies": {
-        "typescript": ">=3.6.5"
-      }
-    },
-    "node_modules/typescript-transform-paths/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "tsconfig-paths-webpack-plugin": "4.2.0",
     "type-fest": "4.32.0",
     "typescript": "5.4.5",
-    "typescript-transform-paths": "3.5.2",
     "webpack": "5.97.1",
     "webpack-cli": "5.1.4",
     "webpack-merge": "6.0.1",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -17,12 +17,7 @@
     "paths": {
       "tldjs": ["@/jslib/src/misc/tldjs.noop"],
       "@/*": ["./*"]
-    },
-    "plugins": [
-      {
-        "transform": "typescript-transform-paths"
-      }
-    ]
+    }
   },
   "include": ["src", "jslib", "scripts", "./*.ts"]
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-16412
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Instead of upgrading `typescript-transform-paths` in #697 , I found that it's no longer required as it's already been replaced by `tsconfig-paths-webpack-plugin` (which is also what `clients` is using). We can remove it with no ill effects.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
