### PR TITLE
[CL-570] Remove deprecated icons from use

### DIFF
--- a/src/app/tabs/dashboard.component.html
+++ b/src/app/tabs/dashboard.component.html
@@ -22,13 +22,11 @@
         class="btn btn-primary"
         [disabled]="startForm.loading"
       >
-        <i class="bwi bwi-play bwi-fw" [hidden]="startForm.loading"></i>
         <i class="bwi bwi-spinner bwi-fw bwi-spin" [hidden]="!startForm.loading"></i>
         {{ "startSync" | i18n }}
       </button>
     </form>
     <button type="button" (click)="stop()" class="btn btn-primary">
-      <i class="bwi bwi-stop bwi-fw"></i>
       {{ "stopSync" | i18n }}
     </button>
     <form #syncForm [appApiAction]="syncPromise" class="d-inline">

--- a/src/app/tabs/dashboard.component.html
+++ b/src/app/tabs/dashboard.component.html
@@ -26,12 +26,11 @@
         {{ "startSync" | i18n }}
       </button>
     </form>
-    <button type="button" (click)="stop()" class="btn btn-primary">
+    <button type="button" (click)="stop()" class="btn btn-danger text-white">
       {{ "stopSync" | i18n }}
     </button>
     <form #syncForm [appApiAction]="syncPromise" class="d-inline">
       <button type="button" (click)="sync()" class="btn btn-primary" [disabled]="syncForm.loading">
-        <i class="bwi bwi-refresh bwi-fw" [ngClass]="{ 'bwi-spin': syncForm.loading }"></i>
         {{ "syncNow" | i18n }}
       </button>
     </form>
@@ -49,7 +48,6 @@
         [disabled]="simForm.loading"
       >
         <i class="bwi bwi-spinner bwi-fw bwi-spin" [hidden]="!simForm.loading"></i>
-        <i class="bwi bwi-bug bwi-fw" [hidden]="simForm.loading"></i>
         {{ "testNow" | i18n }}
       </button>
     </form>

--- a/src/app/tabs/tabs.component.html
+++ b/src/app/tabs/tabs.component.html
@@ -2,19 +2,16 @@
   <ul class="nav nav-tabs mb-3">
     <li class="nav-item">
       <a class="nav-link" routerLink="dashboard" routerLinkActive="active">
-        <i class="bwi bwi-dashboard"></i>
         {{ "dashboard" | i18n }}
       </a>
     </li>
     <li class="nav-item">
       <a class="nav-link" routerLink="settings" routerLinkActive="active">
-        <i class="bwi bwi-cogs"></i>
         {{ "settings" | i18n }}
       </a>
     </li>
     <li class="nav-item">
       <a class="nav-link" routerLink="more" routerLinkActive="active">
-        <i class="bwi bwi-sliders"></i>
         {{ "more" | i18n }}
       </a>
     </li>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-570](https://bitwarden.atlassian.net/browse/CL-570)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We are in the process of switching to a new set of icons. The first step is to deprecate existing icons that won't be getting replacements. In this PR, the design guidance was to remove the icons entirely rather than swap them with icons that will get replacements. This also means removing a few other icons for consistency's sake, and after reviewing with design, changing the button color for the "stop" button to better differentiate it for users who can perceive color.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
|--------|--------|
| <img width="906" alt="Screenshot 2025-03-03 at 11 16 24 AM" src="https://github.com/user-attachments/assets/52ab7353-34bc-4186-bd15-027ee263ca75" /> | <img width="906" alt="Screenshot 2025-03-03 at 11 25 56 AM" src="https://github.com/user-attachments/assets/436f59e9-855c-44aa-a520-ddf9fcafdbbf" /> |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-570]: https://bitwarden.atlassian.net/browse/CL-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ