### PR TITLE
[PM-18708] Change G Suite property name in example to match the docs

### DIFF
--- a/src/app/tabs/settings.component.html
+++ b/src/app/tabs/settings.component.html
@@ -614,7 +614,7 @@
               {{ "ex" | i18n }} exclude:joe&#64;company.com | profile.firstName eq "John"
             </div>
             <div class="form-text" *ngIf="directory === directoryType.GSuite">
-              {{ "ex" | i18n }} exclude:joe&#64;company.com | orgName=Engineering
+              {{ "ex" | i18n }} exclude:joe&#64;company.com | orgUnitPath=/Engineering
             </div>
           </div>
           <div class="mb-3" [hidden]="directory != directoryType.Ldap">


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-18708
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
The linked Jira is not really an issue, the example just shows the wrong g suite for OUs. This PR updates the copy to use the correct property. Otherwise the User filter works as expected.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
