### PR TITLE
[PM-15456] Update AzureDirectoryService to dynamically select Graph API endpoint based on identity authority (public or government)

### DIFF
--- a/src/services/azure-directory.service.ts
+++ b/src/services/azure-directory.service.ts
@@ -18,7 +18,9 @@ import { BaseDirectoryService } from "./baseDirectory.service";
 import { IDirectoryService } from "./directory.service";
 
 const AzurePublicIdentityAuhtority = "login.microsoftonline.com";
+const AzurePublicGraphEndpoint = "https://graph.microsoft.com";
 const AzureGovermentIdentityAuhtority = "login.microsoftonline.us";
+const AzureGovernmentGraphEndpoint = "https://graph.microsoft.us";
 
 const NextLink = "@odata.nextLink";
 const DeltaLink = "@odata.deltaLink";
@@ -207,7 +209,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
     if (keyword === "excludeadministrativeunit" || keyword === "includeadministrativeunit") {
       for (const p of pieces) {
         let auMembers = await this.client
-          .api(`https://graph.microsoft.com/v1.0/directory/administrativeUnits/${p}/members`)
+          .api(`${this.getGraphApiEndpoint()}/v1.0/directory/administrativeUnits/${p}/members`)
           .get();
         // eslint-disable-next-line
         while (true) {
@@ -478,7 +480,7 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
           client_id: this.dirConfig.applicationId,
           client_secret: this.dirConfig.key,
           grant_type: "client_credentials",
-          scope: "https://graph.microsoft.com/.default",
+          scope: `${this.getGraphApiEndpoint()}/.default`,
         });
 
         const req = https
@@ -541,5 +543,11 @@ export class AzureDirectoryService extends BaseDirectoryService implements IDire
     const exp = new Date();
     exp.setSeconds(exp.getSeconds() + expSeconds);
     this.accessTokenExpiration = exp;
+  }
+
+  private getGraphApiEndpoint(): string {
+    return this.dirConfig.identityAuthority === AzureGovermentIdentityAuhtority
+      ? AzureGovernmentGraphEndpoint
+      : AzurePublicGraphEndpoint;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15456

## 📔 Objective

This PR updates the Graph API URL to use the appropriate endpoint based on the selected Identity Authority. If Azure AD Government is selected, the URL now points to the government-specific endpoint (`https://graph.microsoft.us`) instead of the default public one (`https://graph.microsoft.com`).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
