### PR TITLE
SRE-2329 remove auth-email header

### DIFF
--- a/jslib/common/src/models/request/identityToken/passwordTokenRequest.ts
+++ b/jslib/common/src/models/request/identityToken/passwordTokenRequest.ts
@@ -31,7 +31,4 @@ export class PasswordTokenRequest extends TokenRequest implements CaptchaProtect
     return obj;
   }
 
-  alterIdentityTokenHeaders(headers: Headers) {
-    headers.set("Auth-Email", Utils.fromUtf8ToUrlB64(this.email));
-  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SRE-2329

## 📔 Objective

Removing requirement for password token requests.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
