### PR TITLE
[PM-32177] - Fixing Backward Compatibility with Azure AD

### DIFF
--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -204,7 +204,9 @@ export class StateService
       return entraKey;
     }
 
-    await this.secureStorageService.get<string>(`${options.userId}_${SecureStorageKeys.azure}`);
+    return await this.secureStorageService.get<string>(
+      `${options.userId}_${SecureStorageKeys.azure}`,
+    );
   }
 
   private async setEntraKey(value: string, options?: StorageOptions): Promise<void> {
@@ -316,9 +318,17 @@ export class StateService
   }
 
   async getEntraConfiguration(options?: StorageOptions): Promise<EntraIdConfiguration> {
-    return (
+    const entraConfig = (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
     )?.directoryConfigurations?.entra;
+
+    if (entraConfig != null) {
+      return entraConfig;
+    }
+
+    return (
+      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
+    )?.directoryConfigurations?.azure;
   }
 
   async setEntraConfiguration(


### PR DESCRIPTION
## 🎟️ Tracking
[PM-23177](https://bitwarden.atlassian.net/browse/PM-23177)

## 📔 Objective
This fixes the backward compatibility with Azure AD to Entra ID. There needs to be checks for pulling the account configuration. First for entra and if not found, defaults to azure. Then for when fetching the key.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
