### PR TITLE
Add top level permissions key to Github workflows

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -16,17 +16,13 @@ on:
       - "src/services/ldap-directory.service*" # we only have integration for LDAP testing at the moment
       - "./openldap/**/*" # any change to test fixtures
       - "./docker-compose.yml" # any change to Docker configuration
-
+permissions:
+  contents: read
 jobs:
-
   testing:
     name: Run tests
     if: ${{ startsWith(github.head_ref, 'version_bump_') == false }}
     runs-on: ubuntu-22.04
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
 
     steps:
       - name: Check out repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,15 @@ on:
       - "hotfix-rc"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   testing:
     name: Run tests
     if: ${{ startsWith(github.head_ref, 'version_bump_') == false }}
     runs-on: ubuntu-24.04
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
 
     steps:
       - name: Check out repo

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -8,6 +8,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   bump_version:
     name: Bump Version


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21333
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add a top level `permissions` key to all Github workflows per our latest best practice.

The following workflows already had this key added and the existing permissions looked reasonable:
- build (contents: read)
- enforce-labels (contents: read, pull-requests: read)
- release (contents: read)
- scan (none)

I have added or adjusted permissions for the following. However, this is based on my best guess based on what the workflows do, so a second set of eyes from BRE would be appreciated. Further in-line comments below.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
