### PR TITLE
[PM-24965] Remove core-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "browser-hrtime": "1.1.8",
         "chalk": "4.1.2",
         "commander": "14.0.0",
-        "core-js": "3.44.0",
         "form-data": "4.0.4",
         "google-auth-library": "10.1.0",
         "googleapis": "153.0.0",
@@ -11072,17 +11071,6 @@
       },
       "peerDependencies": {
         "webpack": "^5.1.0"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.44.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.44.0.tgz",
-      "integrity": "sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "browser-hrtime": "1.1.8",
     "chalk": "4.1.2",
     "commander": "14.0.0",
-    "core-js": "3.44.0",
     "form-data": "4.0.4",
     "google-auth-library": "10.1.0",
     "googleapis": "153.0.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,3 @@
-import "core-js/stable";
 import "zone.js";
 
 import { NgModule } from "@angular/core";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-24965

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
`core-js` is a polyfill library to support older browsers, however Directory Connector runs on electron and node, which are environments we control.

- Electron 37 uses Chrome 138 (released 2025)
- CLI uses node 20 (released 2023 and under LTS)

... and DC does not see a whole lot of active development.

So I doubt we’re using any newfangled APIs that need polyfilling. QA testing can confirm.

This will avoid upgrading and maintaining this: https://github.com/bitwarden/directory-connector/pull/845.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
