### PR TITLE
[PM-30770] Kerberos auth support to LDAP directory

### DIFF
--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -51,6 +51,24 @@ export class ConfigCommand {
         case "ldap.password":
           await this.setLdapPassword(value);
           break;
+        case "ldap.auth":
+          await this.setLdapAuth(value);
+          break;
+        case "ldap.kerberos.principal":
+          await this.setLdapKerberosPrincipal(value);
+          break;
+        case "ldap.kerberos.keytab":
+          await this.setLdapKerberosKeytab(value);
+          break;
+        case "ldap.kerberos.ccache":
+          await this.setLdapKerberosCcache(value);
+          break;
+        case "ldap.kerberos.mechanism":
+          await this.setLdapKerberosMechanism(value);
+          break;
+        case "ldap.ldapsearch.path":
+          await this.setLdapLdapsearchPath(value);
+          break;
         case "gsuite.key":
           await this.setGSuiteKey(value);
           break;
@@ -98,6 +116,61 @@ export class ConfigCommand {
     this.ldap.password = password;
     await this.saveConfig();
   }
+
+  private async setLdapAuth(auth: string) {
+    auth = auth?.trim()?.toLowerCase();
+    if (auth !== "simple" && auth !== "kerberos") {
+      throw new Error("Invalid ldap.auth value. Allowed values: simple, kerberos.");
+    }
+    await this.loadConfig();
+    (this.ldap as any).auth = auth;
+    await this.saveConfig();
+  }
+
+  private async setLdapKerberosPrincipal(principal: string) {
+    principal = principal === "null" ? null : principal;
+    await this.loadConfig();
+    (this.ldap as any).kerberosPrincipal = principal;
+    await this.saveConfig();
+  }
+
+  private async setLdapKerberosKeytab(keytabPath: string) {
+    keytabPath = keytabPath === "null" ? null : keytabPath;
+    await this.loadConfig();
+    (this.ldap as any).kerberosKeytabPath = keytabPath;
+    await this.saveConfig();
+  }
+
+  private async setLdapKerberosCcache(ccache: string) {
+    ccache = ccache === "null" ? null : ccache;
+    await this.loadConfig();
+    (this.ldap as any).kerberosCcache = ccache;
+    await this.saveConfig();
+  }
+
+  private async setLdapKerberosMechanism(mechanism: string) {
+    mechanism = mechanism?.trim();
+    const mechLower = mechanism?.toLowerCase();
+    let normalized: string;
+    if (mechLower === "gssapi") {
+      normalized = "GSSAPI";
+    } else if (mechLower === "gss-spnego" || mechLower === "gss_spnego" || mechLower === "gssspnego") {
+      normalized = "GSS-SPNEGO";
+    } else {
+      throw new Error("Invalid ldap.kerberos.mechanism value. Allowed values: GSSAPI, GSS-SPNEGO.");
+    }
+    await this.loadConfig();
+    (this.ldap as any).kerberosMechanism = normalized;
+    await this.saveConfig();
+  }
+
+  private async setLdapLdapsearchPath(ldapsearchPath: string) {
+    ldapsearchPath = ldapsearchPath === "null" ? null : ldapsearchPath;
+    await this.loadConfig();
+    (this.ldap as any).ldapsearchPath = ldapsearchPath;
+    await this.saveConfig();
+  }
+
 
   private async setGSuiteKey(key: string) {
     await this.loadConfig();

--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -32,7 +32,9 @@ export class ConfigCommand {
   ) {}
 
   async run(setting: string, value: string, options: program.OptionValues): Promise<Response> {
-    setting = setting.toLowerCase();
+    setting = (setting || "").toLowerCase();
+
+    // Support secretenv/secretfile for any setting (primarily secrets like ldap.password).
     if (value == null || value === "") {
       if (options.secretfile) {
         value = await NodeUtils.readFirstLine(options.secretfile);
@@ -40,14 +42,18 @@ export class ConfigCommand {
         value = process.env[options.secretenv];
       }
     }
+
     try {
       switch (setting) {
+        // Global
         case "server":
           await this.setServer(value);
           break;
         case "directory":
           await this.setDirectory(value);
           break;
+
+        // LDAP core
         case "ldap.hostname":
           await this.setLdapHostname(value);
           break;
@@ -57,9 +63,49 @@ export class ConfigCommand {
         case "ldap.rootpath":
           await this.setLdapRootPath(value);
           break;
+        case "ldap.domain":
+          await this.setLdapDomain(value);
+          break;
+        case "ldap.currentuser":
+          await this.setLdapCurrentUser(value);
+          break;
+        case "ldap.username":
+          await this.setLdapUsername(value);
+          break;
         case "ldap.password":
           await this.setLdapPassword(value);
           break;
+
+        // LDAP TLS/paging
+        case "ldap.ssl":
+          await this.setLdapSsl(value);
+          break;
+        case "ldap.starttls":
+          await this.setLdapStartTls(value);
+          break;
+        case "ldap.tlscapath":
+          await this.setLdapTlsCaPath(value);
+          break;
+        case "ldap.sslcapath":
+          await this.setLdapSslCaPath(value);
+          break;
+        case "ldap.sslcertpath":
+          await this.setLdapSslCertPath(value);
+          break;
+        case "ldap.sslkeypath":
+          await this.setLdapSslKeyPath(value);
+          break;
+        case "ldap.sslallowunauthorized":
+          await this.setLdapSslAllowUnauthorized(value);
+          break;
+        case "ldap.pagedsearch":
+          await this.setLdapPagedSearch(value);
+          break;
+        case "ldap.ad":
+          await this.setLdapAd(value);
+          break;
+
+        // LDAP Kerberos/ldapsearch (custom additions)
         case "ldap.auth":
           await this.setLdapAuth(value);
           break;
@@ -78,6 +124,74 @@ export class ConfigCommand {
         case "ldap.ldapsearch.path":
           await this.setLdapLdapsearchPath(value);
           break;
+
+        // Sync settings
+        case "sync.users":
+          await this.setSyncUsers(value);
+          break;
+        case "sync.groups":
+          await this.setSyncGroups(value);
+          break;
+        case "sync.interval":
+          await this.setSyncInterval(value);
+          break;
+        case "sync.userfilter":
+          await this.setSyncUserFilter(value);
+          break;
+        case "sync.groupfilter":
+          await this.setSyncGroupFilter(value);
+          break;
+        case "sync.removedisabled":
+          await this.setSyncRemoveDisabled(value);
+          break;
+        case "sync.overwriteexisting":
+          await this.setSyncOverwriteExisting(value);
+          break;
+        case "sync.largeimport":
+          await this.setSyncLargeImport(value);
+          break;
+
+        // Sync LDAP-specific knobs
+        // Note: ConnectorUtils.adjustConfigForSave will force AD defaults when ldap.ad === true.
+        // If you need these to persist as custom values, set ldap.ad=false.
+        case "sync.userobjectclass":
+          await this.setSyncUserObjectClass(value);
+          break;
+        case "sync.groupobjectclass":
+          await this.setSyncGroupObjectClass(value);
+          break;
+        case "sync.userpath":
+          await this.setSyncUserPath(value);
+          break;
+        case "sync.grouppath":
+          await this.setSyncGroupPath(value);
+          break;
+        case "sync.groupnameattribute":
+          await this.setSyncGroupNameAttribute(value);
+          break;
+        case "sync.useremailattribute":
+          await this.setSyncUserEmailAttribute(value);
+          break;
+        case "sync.memberattribute":
+          await this.setSyncMemberAttribute(value);
+          break;
+        case "sync.useemailprefixsuffix":
+          await this.setSyncUseEmailPrefixSuffix(value);
+          break;
+        case "sync.emailprefixattribute":
+          await this.setSyncEmailPrefixAttribute(value);
+          break;
+        case "sync.emailsuffix":
+          await this.setSyncEmailSuffix(value);
+          break;
+        case "sync.creationdateattribute":
+          await this.setSyncCreationDateAttribute(value);
+          break;
+        case "sync.revisiondateattribute":
+          await this.setSyncRevisionDateAttribute(value);
+          break;
+
+        // Other directories
         case "gsuite.key":
           await this.setGSuiteKey(value);
           break;
@@ -93,15 +207,59 @@ export class ConfigCommand {
         case "onelogin.secret":
           await this.setOneLoginSecret(value);
           break;
+
         default:
           return Response.badRequest("Unknown setting.");
       }
     } catch (e) {
       return Response.error(e);
     }
+
     const res = new MessageResponse(this.i18nService.t("savedSetting", setting), null);
     return Response.success(res);
   }
+
+  // -----------------------------
+  // Helpers
+  // -----------------------------
+
+  private parseBoolean(value: string, settingName: string): boolean {
+    const v = (value || "").trim().toLowerCase();
+    if (["true", "1", "yes", "y", "on"].includes(v)) {
+      return true;
+    }
+    if (["false", "0", "no", "n", "off"].includes(v)) {
+      return false;
+    }
+    throw new Error(`Invalid ${settingName} value. Use true/false.`);
+  }
+
+  private parseNullableString(value: string): string {
+    if (value == null) {
+      return null;
+    }
+    const v = value.trim();
+    if (v.toLowerCase() === "null") {
+      return null;
+    }
+    return v;
+  }
+
+  private parseNullableInt(value: string, settingName: string): number {
+    const v = this.parseNullableString(value);
+    if (v == null) {
+      return null;
+    }
+    const n = parseInt(v, 10);
+    if (!Number.isFinite(n)) {
+      throw new Error(`Invalid ${settingName} value. Must be an integer (or "null").`);
+    }
+    return n;
+  }
+
+  // -----------------------------
+  // Global
+  // -----------------------------
 
   private async setServer(url: string) {
     url = url === "null" || url === "bitwarden.com" || url === "https://bitwarden.com" ? null : url;
@@ -120,91 +278,175 @@ export class ConfigCommand {
     await this.saveConfig();
   }
 
+  // -----------------------------
+  // LDAP core
+  // -----------------------------
+
   private async setLdapHostname(hostname: string) {
-    hostname = hostname === "null" ? null : hostname;
-    if (hostname != null) {
-      hostname = hostname.trim();
-      if (hostname.length === 0) {
-        throw new Error('ldap.hostname cannot be empty (use "null" to clear).');
-      }
+    const v = this.parseNullableString(hostname);
+    if (v != null && v.length === 0) {
+      throw new Error('ldap.hostname cannot be empty (use "null" to clear).');
     }
     await this.loadConfig();
-    this.ldap.hostname = hostname;
+    this.ldap.hostname = v;
     await this.saveConfig();
   }
 
   private async setLdapPort(port: string) {
-    port = port === "null" ? null : port;
-    let parsed: number = null;
-    if (port != null) {
-      const p = parseInt(port, 10);
-      if (!Number.isFinite(p) || p < 1 || p > 65535) {
-        throw new Error('ldap.port must be an integer between 1 and 65535 (or "null" to clear).');
-      }
-      parsed = p;
+    const n = this.parseNullableInt(port, "ldap.port");
+    if (n != null && (n < 1 || n > 65535)) {
+      throw new Error('ldap.port must be between 1 and 65535 (or "null" to clear).');
     }
     await this.loadConfig();
-    this.ldap.port = parsed;
+    this.ldap.port = n;
     await this.saveConfig();
   }
 
   private async setLdapRootPath(rootPath: string) {
-    rootPath = rootPath === "null" ? null : rootPath;
-    if (rootPath != null) {
-      rootPath = rootPath.trim();
-      if (rootPath.length === 0) {
-        throw new Error('ldap.rootPath cannot be empty (use "null" to clear).');
-      }
+    const v = this.parseNullableString(rootPath);
+    if (v != null && v.length === 0) {
+      throw new Error('ldap.rootPath cannot be empty (use "null" to clear).');
     }
     await this.loadConfig();
-    this.ldap.rootPath = rootPath;
+    this.ldap.rootPath = v;
+    await this.saveConfig();
+  }
+
+  private async setLdapDomain(domain: string) {
+    const v = this.parseNullableString(domain);
+    await this.loadConfig();
+    this.ldap.domain = v;
+    await this.saveConfig();
+  }
+
+  private async setLdapCurrentUser(currentUser: string) {
+    const b = this.parseBoolean(currentUser, "ldap.currentUser");
+    await this.loadConfig();
+    this.ldap.currentUser = b;
+    await this.saveConfig();
+  }
+
+  private async setLdapUsername(username: string) {
+    const v = this.parseNullableString(username);
+    await this.loadConfig();
+    this.ldap.username = v;
     await this.saveConfig();
   }
 
   private async setLdapPassword(password: string) {
     await this.loadConfig();
-    this.ldap.password = password;
+    this.ldap.password = this.parseNullableString(password);
     await this.saveConfig();
   }
 
+  // -----------------------------
+  // LDAP TLS / paging / AD
+  // -----------------------------
+
+  private async setLdapSsl(value: string) {
+    const b = this.parseBoolean(value, "ldap.ssl");
+    await this.loadConfig();
+    this.ldap.ssl = b;
+    await this.saveConfig();
+  }
+
+  private async setLdapStartTls(value: string) {
+    const b = this.parseBoolean(value, "ldap.startTls");
+    await this.loadConfig();
+    this.ldap.startTls = b;
+    await this.saveConfig();
+  }
+
+  private async setLdapTlsCaPath(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.ldap.tlsCaPath = v;
+    await this.saveConfig();
+  }
+
+  private async setLdapSslCaPath(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.ldap.sslCaPath = v;
+    await this.saveConfig();
+  }
+
+  private async setLdapSslCertPath(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.ldap.sslCertPath = v;
+    await this.saveConfig();
+  }
+
+  private async setLdapSslKeyPath(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.ldap.sslKeyPath = v;
+    await this.saveConfig();
+  }
+
+  private async setLdapSslAllowUnauthorized(value: string) {
+    const b = this.parseBoolean(value, "ldap.sslAllowUnauthorized");
+    await this.loadConfig();
+    this.ldap.sslAllowUnauthorized = b;
+    await this.saveConfig();
+  }
+
+  private async setLdapPagedSearch(value: string) {
+    const b = this.parseBoolean(value, "ldap.pagedSearch");
+    await this.loadConfig();
+    this.ldap.pagedSearch = b;
+    await this.saveConfig();
+  }
+
+  private async setLdapAd(value: string) {
+    const b = this.parseBoolean(value, "ldap.ad");
+    await this.loadConfig();
+    this.ldap.ad = b;
+    await this.saveConfig();
+  }
+
+  // -----------------------------
+  // LDAP Kerberos / ldapsearch additions
+  // -----------------------------
+
   private async setLdapAuth(auth: string) {
-    auth = auth?.trim()?.toLowerCase();
-    if (auth !== "simple" && auth !== "kerberos") {
+    const v = (auth || "").trim().toLowerCase();
+    if (v !== "simple" && v !== "kerberos") {
       throw new Error("Invalid ldap.auth value. Allowed values: simple, kerberos.");
     }
     await this.loadConfig();
-    (this.ldap as any).auth = auth;
+    (this.ldap as any).auth = v;
     await this.saveConfig();
   }
 
   private async setLdapKerberosPrincipal(principal: string) {
-    principal = principal === "null" ? null : principal;
+    const v = this.parseNullableString(principal);
     await this.loadConfig();
-    (this.ldap as any).kerberosPrincipal = principal;
+    (this.ldap as any).kerberosPrincipal = v;
     await this.saveConfig();
   }
 
   private async setLdapKerberosKeytab(keytabPath: string) {
-    keytabPath = keytabPath === "null" ? null : keytabPath;
+    const v = this.parseNullableString(keytabPath);
     await this.loadConfig();
-    (this.ldap as any).kerberosKeytabPath = keytabPath;
+    (this.ldap as any).kerberosKeytabPath = v;
     await this.saveConfig();
   }
 
   private async setLdapKerberosCcache(ccache: string) {
-    ccache = ccache === "null" ? null : ccache;
+    const v = this.parseNullableString(ccache);
     await this.loadConfig();
-    (this.ldap as any).kerberosCcache = ccache;
+    (this.ldap as any).kerberosCcache = v;
     await this.saveConfig();
   }
 
   private async setLdapKerberosMechanism(mechanism: string) {
-    mechanism = mechanism?.trim();
-    const mechLower = mechanism?.toLowerCase();
+    const m = (mechanism || "").trim().toLowerCase();
     let normalized: string;
-    if (mechLower === "gssapi") {
+    if (m === "gssapi") {
       normalized = "GSSAPI";
-    } else if (mechLower === "gss-spnego" || mechLower === "gss_spnego" || mechLower === "gssspnego") {
+    } else if (m === "gss-spnego" || m === "gss_spnego" || m === "gssspnego") {
       normalized = "GSS-SPNEGO";
     } else {
       throw new Error("Invalid ldap.kerberos.mechanism value. Allowed values: GSSAPI, GSS-SPNEGO.");
@@ -215,11 +457,162 @@ export class ConfigCommand {
   }
 
   private async setLdapLdapsearchPath(ldapsearchPath: string) {
-    ldapsearchPath = ldapsearchPath === "null" ? null : ldapsearchPath;
+    const v = this.parseNullableString(ldapsearchPath);
     await this.loadConfig();
-    (this.ldap as any).ldapsearchPath = ldapsearchPath;
+    (this.ldap as any).ldapsearchPath = v;
     await this.saveConfig();
   }
+
+  // -----------------------------
+  // Sync settings
+  // -----------------------------
+
+  private async setSyncUsers(value: string) {
+    const b = this.parseBoolean(value, "sync.users");
+    await this.loadConfig();
+    this.sync.users = b;
+    await this.saveConfig();
+  }
+
+  private async setSyncGroups(value: string) {
+    const b = this.parseBoolean(value, "sync.groups");
+    await this.loadConfig();
+    this.sync.groups = b;
+    await this.saveConfig();
+  }
+
+  private async setSyncInterval(value: string) {
+    const n = this.parseNullableInt(value, "sync.interval");
+    if (n != null && n < 0) {
+      throw new Error('sync.interval must be >= 0 (or "null" to clear).');
+    }
+    await this.loadConfig();
+    this.sync.interval = n;
+    await this.saveConfig();
+  }
+
+  private async setSyncUserFilter(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.userFilter = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncGroupFilter(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.groupFilter = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncRemoveDisabled(value: string) {
+    const b = this.parseBoolean(value, "sync.removeDisabled");
+    await this.loadConfig();
+    this.sync.removeDisabled = b;
+    await this.saveConfig();
+  }
+
+  private async setSyncOverwriteExisting(value: string) {
+    const b = this.parseBoolean(value, "sync.overwriteExisting");
+    await this.loadConfig();
+    this.sync.overwriteExisting = b;
+    await this.saveConfig();
+  }
+
+  private async setSyncLargeImport(value: string) {
+    const b = this.parseBoolean(value, "sync.largeImport");
+    await this.loadConfig();
+    this.sync.largeImport = b;
+    await this.saveConfig();
+  }
+
+  private async setSyncUserObjectClass(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.userObjectClass = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncGroupObjectClass(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.groupObjectClass = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncUserPath(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.userPath = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncGroupPath(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.groupPath = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncGroupNameAttribute(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.groupNameAttribute = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncUserEmailAttribute(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.userEmailAttribute = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncMemberAttribute(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.memberAttribute = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncUseEmailPrefixSuffix(value: string) {
+    const b = this.parseBoolean(value, "sync.useEmailPrefixSuffix");
+    await this.loadConfig();
+    this.sync.useEmailPrefixSuffix = b;
+    await this.saveConfig();
+  }
+
+  private async setSyncEmailPrefixAttribute(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.emailPrefixAttribute = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncEmailSuffix(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.emailSuffix = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncCreationDateAttribute(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.creationDateAttribute = v;
+    await this.saveConfig();
+  }
+
+  private async setSyncRevisionDateAttribute(value: string) {
+    const v = this.parseNullableString(value);
+    await this.loadConfig();
+    this.sync.revisionDateAttribute = v;
+    await this.saveConfig();
+  }
+
+  // -----------------------------
+  // Other directory configs
+  // -----------------------------
 
   private async setGSuiteKey(key: string) {
     await this.loadConfig();

--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -48,6 +48,15 @@ export class ConfigCommand {
         case "directory":
           await this.setDirectory(value);
           break;
+        case "ldap.hostname":
+          await this.setLdapHostname(value);
+          break;
+        case "ldap.port":
+          await this.setLdapPort(value);
+          break;
+        case "ldap.rootpath":
+          await this.setLdapRootPath(value);
+          break;
         case "ldap.password":
           await this.setLdapPassword(value);
           break;
@@ -111,6 +120,47 @@ export class ConfigCommand {
     await this.saveConfig();
   }
 
+  private async setLdapHostname(hostname: string) {
+    hostname = hostname === "null" ? null : hostname;
+    if (hostname != null) {
+      hostname = hostname.trim();
+      if (hostname.length === 0) {
+        throw new Error('ldap.hostname cannot be empty (use "null" to clear).');
+      }
+    }
+    await this.loadConfig();
+    this.ldap.hostname = hostname;
+    await this.saveConfig();
+  }
+
+  private async setLdapPort(port: string) {
+    port = port === "null" ? null : port;
+    let parsed: number = null;
+    if (port != null) {
+      const p = parseInt(port, 10);
+      if (!Number.isFinite(p) || p < 1 || p > 65535) {
+        throw new Error('ldap.port must be an integer between 1 and 65535 (or "null" to clear).');
+      }
+      parsed = p;
+    }
+    await this.loadConfig();
+    this.ldap.port = parsed;
+    await this.saveConfig();
+  }
+
+  private async setLdapRootPath(rootPath: string) {
+    rootPath = rootPath === "null" ? null : rootPath;
+    if (rootPath != null) {
+      rootPath = rootPath.trim();
+      if (rootPath.length === 0) {
+        throw new Error('ldap.rootPath cannot be empty (use "null" to clear).');
+      }
+    }
+    await this.loadConfig();
+    this.ldap.rootPath = rootPath;
+    await this.saveConfig();
+  }
+
   private async setLdapPassword(password: string) {
     await this.loadConfig();
     this.ldap.password = password;
@@ -170,7 +220,6 @@ export class ConfigCommand {
     (this.ldap as any).ldapsearchPath = ldapsearchPath;
     await this.saveConfig();
   }
-
 
   private async setGSuiteKey(key: string) {
     await this.loadConfig();

--- a/src/commands/login.command.spec.ts
+++ b/src/commands/login.command.spec.ts
@@ -1,11 +1,14 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { AuthService } from "../abstractions/auth.service";
+import { StateService } from "../abstractions/state.service";
 
 import { LoginCommand } from "./login.command";
 
 const clientId = "test_client_id";
 const clientSecret = "test_client_secret";
+const orgId = "00000000-0000-0000-0000-000000000000";
+const orgClientId = `organization.${orgId}`;
 
 // Mock responses from the inquirer prompt
 // This combines both prompt results into a single object which is returned both times
@@ -18,6 +21,7 @@ jest.mock("inquirer", () => ({
 
 describe("LoginCommand", () => {
   let authService: MockProxy<AuthService>;
+  let stateService: MockProxy<StateService>;
 
   let loginCommand: LoginCommand;
 
@@ -27,8 +31,9 @@ describe("LoginCommand", () => {
     delete process.env.BW_CLIENTSECRET;
 
     authService = mock();
+    stateService = mock();
 
-    loginCommand = new LoginCommand(authService);
+    loginCommand = new LoginCommand(authService, stateService);
   });
 
   it("uses client id and secret stored in environment variables", async () => {
@@ -38,6 +43,24 @@ describe("LoginCommand", () => {
     const result = await loginCommand.run();
 
     expect(authService.logIn).toHaveBeenCalledWith({ clientId, clientSecret });
+    expect(stateService.setOrganizationId).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      data: {
+        title: "You are logged in!",
+      },
+      success: true,
+    });
+  });
+
+
+  it("sets organization id when client id is organization-scoped", async () => {
+    process.env.BW_CLIENTID = orgClientId;
+    process.env.BW_CLIENTSECRET = clientSecret;
+
+    const result = await loginCommand.run();
+
+    expect(authService.logIn).toHaveBeenCalledWith({ clientId: orgClientId, clientSecret });
+    expect(stateService.setOrganizationId).toHaveBeenCalledWith(orgId);
     expect(result).toMatchObject({
       data: {
         title: "You are logged in!",
@@ -50,6 +73,7 @@ describe("LoginCommand", () => {
     const result = await loginCommand.run();
 
     expect(authService.logIn).toHaveBeenCalledWith({ clientId, clientSecret });
+    expect(stateService.setOrganizationId).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       data: {
         title: "You are logged in!",

--- a/src/program.ts
+++ b/src/program.ts
@@ -92,7 +92,7 @@ export class Program extends BaseProgram {
       })
       .action(async (clientId: string, clientSecret: string, options: OptionValues) => {
         await this.exitIfAuthed();
-        const command = new LoginCommand(this.main.authService);
+	const command = new LoginCommand(this.main.authService, this.main.stateService);
 
         if (!Utils.isNullOrWhitespace(clientId)) {
           process.env.BW_CLIENTID = clientId;

--- a/src/program.ts
+++ b/src/program.ts
@@ -190,6 +190,11 @@ export class Program extends BaseProgram {
         writeLn("    server - On-premise hosted installation URL.");
         writeLn("    directory - The type of directory to use.");
         writeLn("    ldap.password - The password for connection to this LDAP server.");
+        writeLn("    ldap.auth - Authentication mode for LDAP (simple|kerberos).");
+        writeLn("    ldap.kerberos.principal - Kerberos principal (e.g. svc_bwdc@EXAMPLE.COM).");
+        writeLn("    ldap.kerberos.keytab - Path to keytab file.");
+        writeLn("    ldap.kerberos.ccache - Optional ccache path (e.g. /tmp/krb5cc_bwdc).");
+        writeLn("    ldap.ldapsearch.path - Optional ldapsearch binary path (default: ldapsearch).");
         writeLn("    entra.key - The Entra Id secret key.");
         writeLn("    gsuite.key - The G Suite private key.");
         writeLn("    okta.token - The Okta token.");


### PR DESCRIPTION
## 🎟️ Tracking

None

## 📔 Objective

Add support for kerberos authentication for LDAP directory connections.  This allows the hosting endpoint's crednetials (or a user's crednetials) to authenticate to an LDAP server with kerberos.  This sidesteps many increasingly difficult security policies forbidding the use of password secrets and password rotation. (if the endpoints krb credentials are managed by sssd, they are auto rotated every 30 days)

## 📸 Screenshots

 no UI. CLI changes only.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
