### PR TITLE
[PM-33767] fix: validate organizationId in bwdc test to surface missing config early

### DIFF
--- a/src/services/sync.service.spec.ts
+++ b/src/services/sync.service.spec.ts
@@ -68,6 +68,20 @@ describe("SyncService", () => {
     );
   });
 
+  it("Sync throws 'Organization not set.' when organizationId is missing", async () => {
+    stateService.getOrganizationId.mockResolvedValue(null);
+    stateService.getSync.mockResolvedValue(getSyncConfiguration({ groups: true, users: true }));
+
+    await expect(syncService.sync(true, false)).rejects.toThrow("Organization not set.");
+  });
+
+  it("bwdc test (test=true) throws 'Organization not set.' when organizationId is missing", async () => {
+    stateService.getOrganizationId.mockResolvedValue(null);
+    stateService.getSync.mockResolvedValue(getSyncConfiguration({ groups: true, users: true }));
+
+    await expect(syncService.sync(true, true)).rejects.toThrow("Organization not set.");
+  });
+
   it("Sync posts single request successfully for unique hashes", async () => {
     stateService.getSync.mockResolvedValue(getSyncConfiguration({ groups: true, users: true }));
     cryptoFunctionService.hash.mockResolvedValue(new ArrayBuffer(1));

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -49,6 +49,11 @@ export class SyncService {
       throw new Error("Cannot load directory service.");
     }
 
+    const orgId = await this.stateService.getOrganizationId();
+    if (orgId == null) {
+      throw new Error("Organization not set.");
+    }
+
     const syncConfig = await this.stateService.getSync();
     const startingGroupDelta = await this.stateService.getGroupDelta();
     const startingUserDelta = await this.stateService.getUserDelta();


### PR DESCRIPTION
## Problem

Fixes #141

When `organizationId` is missing from `data.json`, `bwdc test` completes successfully showing users and groups, but `bwdc sync` fails with `Organization not set.`. This makes `bwdc test` misleading — a passing test implies the configuration is ready for sync, but it is not.

## Root Cause

The `organizationId` validation only occurs in `generateHash()`, which is only called during a real sync (not in test mode). In test mode, `sync()` returns early before reaching this validation.

## Fix

Move the `organizationId` check to the beginning of `sync()`, before any directory queries are made. This ensures both `bwdc test` and `bwdc sync` fail fast with a clear `Organization not set.` error when the organization is not configured.

## Tests

Added two new unit tests:
- `Sync throws 'Organization not set.' when organizationId is missing`
- `bwdc test (test=true) throws 'Organization not set.' when organizationId is missing`

All existing tests continue to pass.