### PR TITLE
[PM-35355] Fix logout clearing directory config state

### DIFF
--- a/libs/abstractions/state.service.ts
+++ b/libs/abstractions/state.service.ts
@@ -83,8 +83,6 @@ export abstract class StateService {
 
   // Lifecycle methods
   abstract init(): Promise<void>;
-  abstract clean(): Promise<void>;
-  abstract clearDirectoryConfigurations(): Promise<void>;
 
   // Additional state methods
   abstract getLocale(): Promise<string>;

--- a/libs/services/state-service/default-state.service.spec.ts
+++ b/libs/services/state-service/default-state.service.spec.ts
@@ -98,28 +98,6 @@ describe("DefaultStateService", () => {
     });
   });
 
-  describe("clean", () => {
-    it("preserves directory configurations across logout", async () => {
-      await stateService.setDirectoryType(DirectoryType.Ldap);
-      await stateService.setOrganizationId("org-123");
-      await stateService.setSync({ users: true } as SyncConfiguration);
-
-      await stateService.clean();
-
-      expect(await stateService.getDirectoryType()).toBe(DirectoryType.Ldap);
-      expect(await stateService.getOrganizationId()).toBe("org-123");
-      expect(await stateService.getSync()).toEqual({ users: true });
-    });
-
-    it("does not touch secure storage during clean", async () => {
-      await stateService.setAccessToken("tok");
-
-      await stateService.clean();
-
-      expect(secureStorage.store.get(SecureStorageKeys.accessToken)).toBe("tok");
-    });
-  });
-
   describe("Directory Type", () => {
     it("round-trips the directory type", async () => {
       await stateService.setDirectoryType(DirectoryType.Ldap);

--- a/libs/services/state-service/default-state.service.spec.ts
+++ b/libs/services/state-service/default-state.service.spec.ts
@@ -99,16 +99,16 @@ describe("DefaultStateService", () => {
   });
 
   describe("clean", () => {
-    it("clears directory type, org ID, and sync from regular storage", async () => {
+    it("preserves directory configurations across logout", async () => {
       await stateService.setDirectoryType(DirectoryType.Ldap);
       await stateService.setOrganizationId("org-123");
       await stateService.setSync({ users: true } as SyncConfiguration);
 
       await stateService.clean();
 
-      expect(await stateService.getDirectoryType()).toBeNull();
-      expect(await stateService.getOrganizationId()).toBeNull();
-      expect(await stateService.getSync()).toBeNull();
+      expect(await stateService.getDirectoryType()).toBe(DirectoryType.Ldap);
+      expect(await stateService.getOrganizationId()).toBe("org-123");
+      expect(await stateService.getSync()).toEqual({ users: true });
     });
 
     it("does not touch secure storage during clean", async () => {
@@ -116,7 +116,6 @@ describe("DefaultStateService", () => {
 
       await stateService.clean();
 
-      // secure storage still has the access token — clean only clears directory state
       expect(secureStorage.store.get(SecureStorageKeys.accessToken)).toBe("tok");
     });
   });

--- a/libs/services/state-service/default-state.service.ts
+++ b/libs/services/state-service/default-state.service.ts
@@ -30,7 +30,8 @@ export class DefaultStateService implements StateService {
   }
 
   async clean(): Promise<void> {
-    await this.clearDirectoryConfigurations();
+    // Auth tokens are cleared separately via clearAuthTokens().
+    // Directory configurations persist across logout/login cycles.
   }
 
   /**

--- a/libs/services/state-service/default-state.service.ts
+++ b/libs/services/state-service/default-state.service.ts
@@ -29,27 +29,6 @@ export class DefaultStateService implements StateService {
     }
   }
 
-  async clean(): Promise<void> {
-    // Auth tokens are cleared separately via clearAuthTokens().
-    // Directory configurations persist across logout/login cycles.
-  }
-
-  /**
-   * Clears all directory settings and configurations
-   * but preserve version and environment settings
-   */
-  async clearDirectoryConfigurations(): Promise<void> {
-    await this.setDirectoryType(null);
-    await this.setOrganizationId(null);
-    await this.setSync(null);
-    await this.setLdapConfiguration(null);
-    await this.setGsuiteConfiguration(null);
-    await this.setEntraConfiguration(null);
-    await this.setOktaConfiguration(null);
-    await this.setOneLoginConfiguration(null);
-    await this.clearSyncSettings(true);
-  }
-
   // ===================================================================
   // Directory Configuration Methods
   // ===================================================================

--- a/src-cli/bwdc.ts
+++ b/src-cli/bwdc.ts
@@ -172,7 +172,6 @@ export class Main {
 
   async logout() {
     await this.stateService.clearAuthTokens();
-    await this.stateService.clean();
   }
 
   private async init() {

--- a/src-gui/app/app.component.ts
+++ b/src-gui/app/app.component.ts
@@ -116,7 +116,6 @@ export class AppComponent implements OnInit {
 
   private async logOut(expired: boolean) {
     await this.stateService.clearAuthTokens();
-    await this.stateService.clean();
 
     this.authService.logOut(async () => {
       if (expired) {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-35355
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Removes the logic to clear directory sync config. This was not part of original functionality, so it will be removed. As far as I can tell, this specific bug originated from the work done in the dev clarity session (where it first appears in git history). The original functionality on log out was to just de-auth the logged in session, not clear sync settings too.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
