### PR TITLE
Add prettier to precommit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ Thumbs.db
 # Environment variables used for tests
 .env
 
+# Toolchain
+.eslintcache
+
 # IDEs and editors
 .idea/
 .project

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,4 @@
+export default {
+  "*": "prettier --cache --ignore-unknown --write",
+  "*.ts": "eslint --cache --cache-strategy content --fix",
+};

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build:native:release": "cd native && npm install && npm run build:release",
     "rebuild": "npm run build:native:release",
     "lint": "eslint . && prettier --check .",
-    "lint:fix": "eslint . --fix",
+    "lint:fix": "eslint . --fix && prettier --write .",
     "build": "concurrently -n Main,Rend -c yellow,cyan \"npm run build:main\" \"npm run build:renderer\"",
     "build:main": "webpack --config webpack.main.mjs",
     "build:renderer": "webpack --config webpack.renderer.mjs",
@@ -168,6 +168,6 @@
     "npm": "~10"
   },
   "lint-staged": {
-    "*.ts": "eslint --fix"
+    "*.ts": "npm run lint:fix"
   }
 }

--- a/package.json
+++ b/package.json
@@ -166,8 +166,5 @@
   "engines": {
     "node": "~25",
     "npm": "~10"
-  },
-  "lint-staged": {
-    "*.ts": "npm run lint:fix"
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
N/A
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
I noticed that eslint runs on commit, but prettier doesn't. It is checked by the pipeline in `lint.yml` but we want it as part of the development workflow.

Move configuration to a separate file and copy the same options as `clients`, for both eslint and prettier.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
