### PR TITLE
[PM-38508] Set state version after every migration check

### DIFF
--- a/libs/services/state-service/default-state.service.spec.ts
+++ b/libs/services/state-service/default-state.service.spec.ts
@@ -28,6 +28,7 @@ function makeMigrationService(needsMigration = false): StateMigrationService {
   return {
     needsMigration: jest.fn().mockResolvedValue(needsMigration),
     migrate: jest.fn().mockResolvedValue(undefined),
+    stampVersion: jest.fn().mockResolvedValue(undefined),
   } as unknown as StateMigrationService;
 }
 
@@ -95,6 +96,17 @@ describe("DefaultStateService", () => {
 
       expect(migrationService.needsMigration).toHaveBeenCalled();
       expect(migrationService.migrate).not.toHaveBeenCalled();
+    });
+
+    it("always calls stampVersion regardless of whether migration ran", async () => {
+      for (const needed of [true, false]) {
+        const migrationService = makeMigrationService(needed);
+        const svc = makeStateService(storage, secureStorage, true, migrationService);
+
+        await svc.init();
+
+        expect(migrationService.stampVersion).toHaveBeenCalled();
+      }
     });
   });
 

--- a/libs/services/state-service/default-state.service.ts
+++ b/libs/services/state-service/default-state.service.ts
@@ -27,6 +27,7 @@ export class DefaultStateService implements StateService {
     if (await this.stateMigrationService.needsMigration()) {
       await this.stateMigrationService.migrate();
     }
+    await this.stateMigrationService.stampVersion();
   }
 
   // ===================================================================

--- a/libs/services/state-service/stateMigration.service.spec.ts
+++ b/libs/services/state-service/stateMigration.service.spec.ts
@@ -594,6 +594,22 @@ describe("StateMigrationService", () => {
       });
     });
 
+    describe("stampVersion()", () => {
+      it("writes stateVersion = Latest when stateVersion is absent (fresh install)", async () => {
+        await svc.stampVersion();
+
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Six);
+      });
+
+      it("does not overwrite an existing stateVersion", async () => {
+        storage.store.set(StorageKeys.stateVersion, StateVersion.Five);
+
+        await svc.stampVersion();
+
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Five);
+      });
+    });
+
     describe("getCurrentStateVersion() (tested indirectly via needsMigration)", () => {
       it("returns StateVersion.Latest (no migration needed) when both flat key and globals are absent (fresh install)", async () => {
         // Completely empty storage — treat as fresh install

--- a/libs/services/state-service/stateMigration.service.ts
+++ b/libs/services/state-service/stateMigration.service.ts
@@ -30,6 +30,18 @@ export class StateMigrationService {
     return currentStateVersion == null || currentStateVersion < StateVersion.Latest;
   }
 
+  /**
+   * Ensure stateVersion is persisted in storage. On a fresh install needsMigration() returns
+   * false (no data to migrate) so migrate() is never called, leaving stateVersion absent from
+   * data.json. Calling this after the migration check guarantees the key is always written.
+   */
+  async stampVersion(): Promise<void> {
+    const stored = await this.get<StateVersion>(StorageKeys.stateVersion);
+    if (stored == null) {
+      await this.set(StorageKeys.stateVersion, StateVersion.Latest);
+    }
+  }
+
   async migrate(): Promise<void> {
     let currentStateVersion = await this.getCurrentStateVersion();
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-38508
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Ensure stateVersion is persisted in storage. On a fresh install `needsMigration()` returns `false` (no data to migrate) so `migrate()` is never called, leaving `stateVersion` absent from `data.json`. Adds a call after the migration check to guarantee the key is always written.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
