### PR TITLE
[PM-38509] Pass native node fetch to JWT client's transportOptions

### DIFF
--- a/libs/services/directory-services/gsuite-directory.service.ts
+++ b/libs/services/directory-services/gsuite-directory.service.ts
@@ -249,6 +249,7 @@ export class GSuiteDirectoryService extends BaseDirectoryService implements IDir
         "https://www.googleapis.com/auth/admin.directory.group.readonly",
         "https://www.googleapis.com/auth/admin.directory.group.member.readonly",
       ],
+      transporterOptions: { fetchImplementation: globalThis.fetch.bind(globalThis) },
     });
 
     try {

--- a/webpack.cli.mjs
+++ b/webpack.cli.mjs
@@ -37,10 +37,6 @@ const plugins = [
     banner: "#!/usr/bin/env node",
     raw: true,
   }),
-  new webpack.IgnorePlugin({
-    resourceRegExp: /^node-fetch$/,
-    contextRegExp: /gaxios/,
-  }),
 ];
 
 const config = {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-38509
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
google-auth-library uses gaxios as its HTTP client. Gaxios lazily resolves its fetch implementation at runtime: if window is defined it uses window.fetch, otherwise it falls back to a dynamic import('node-fetch'). There's no window in the CLI so gaxios tried to dynamically import node-fetch (which was removed with DC modernization). Pass the native node fetch to the client's trasnporterOptions so it doesn't try to dynamically import node-fetch.

also removes IgnorePlugin which suppresses errors about this.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
