### PR TITLE
[PM-39571] Fix missing null check in migration

### DIFF
--- a/libs/services/state-service/stateMigration.service.ts
+++ b/libs/services/state-service/stateMigration.service.ts
@@ -178,13 +178,13 @@ export class StateMigrationService {
       }
 
       // Migrate apiKeyClientId and apiKeyClientSecret from account object to secure storage
-      if (account.profile.apiKeyClientId) {
+      if (account.profile?.apiKeyClientId) {
         await this.secureStorageService.save(
           SecureStorageKeys.apiKeyClientId,
           account.profile.apiKeyClientId,
         );
       }
-      if (account.keys.apiKeyClientSecret) {
+      if (account.keys?.apiKeyClientSecret) {
         await this.secureStorageService.save(
           SecureStorageKeys.apiKeyClientSecret,
           account.keys.apiKeyClientSecret,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-39571
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
When we attempt to migrate the client id into secure storage, if there is no logged in account (no profile object) then missing null check throws.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
