### PR TITLE
[PM-37965] Milestone 2 - Staged Users

### DIFF
--- a/libs/abstractions/request-builder.service.ts
+++ b/libs/abstractions/request-builder.service.ts
@@ -5,6 +5,7 @@ import { UserEntry } from "@/libs/models/userEntry";
 export interface RequestBuilderOptions {
   removeDisabled: boolean;
   overwriteExisting: boolean;
+  inviteUsersAfterProvisioning: boolean;
 }
 
 export abstract class RequestBuilder {

--- a/libs/enums/stateVersion.ts
+++ b/libs/enums/stateVersion.ts
@@ -6,5 +6,6 @@ export enum StateVersion {
   Five = 5, // New state service implementation
   Six = 6, // Migrate Windows Credential Manager entries from keytar (UTF-8) to desktop_core (UTF-16)
   Seven = 7, // Re-run legacy keytar credential migration for machines stuck at v6 with un-migrated {userId}_* credentials
-  Latest = Seven,
+  Eight = 8, // Backfill inviteUsersAfterProvisioning=true onto existing sync configs to preserve behavior
+  Latest = Eight,
 }

--- a/libs/enums/stateVersion.ts
+++ b/libs/enums/stateVersion.ts
@@ -5,5 +5,6 @@ export enum StateVersion {
   Four = 4, // Fix 'Never Lock' option by removing stale data
   Five = 5, // New state service implementation
   Six = 6, // Migrate Windows Credential Manager entries from keytar (UTF-8) to desktop_core (UTF-16)
-  Latest = Six,
+  Seven = 7, // Backfill inviteUsersAfterProvisioning=true onto existing sync configs to preserve behavior
+  Latest = Seven,
 }

--- a/libs/models/request/organizationImportRequest.ts
+++ b/libs/models/request/organizationImportRequest.ts
@@ -7,12 +7,14 @@ export class OrganizationImportRequest {
   members: OrganizationImportMemberRequest[] = [];
   overwriteExisting = false;
   largeImport = false;
+  inviteUsersAfterProvisioning = true;
 
   constructor(model: {
     groups: Required<OrganizationImportGroupRequest>[];
     users: Required<OrganizationImportMemberRequest>[];
     overwriteExisting: boolean;
     largeImport: boolean;
+    inviteUsersAfterProvisioning?: boolean;
   }) {
     if (model instanceof ImportDirectoryRequest) {
       this.groups = model.groups.map((g) => new OrganizationImportGroupRequest(g));
@@ -23,5 +25,7 @@ export class OrganizationImportRequest {
     }
     this.overwriteExisting = model.overwriteExisting;
     this.largeImport = model.largeImport;
+    // Defaults to true so existing configurations (where the flag is absent) keep sending invitations.
+    this.inviteUsersAfterProvisioning = model.inviteUsersAfterProvisioning ?? true;
   }
 }

--- a/libs/models/request/organizationImportRequest.ts
+++ b/libs/models/request/organizationImportRequest.ts
@@ -7,7 +7,7 @@ export class OrganizationImportRequest {
   members: OrganizationImportMemberRequest[] = [];
   overwriteExisting = false;
   largeImport = false;
-  inviteUsersAfterProvisioning = true;
+  inviteUsersAfterProvisioning = false;
 
   constructor(model: {
     groups: Required<OrganizationImportGroupRequest>[];
@@ -25,7 +25,7 @@ export class OrganizationImportRequest {
     }
     this.overwriteExisting = model.overwriteExisting;
     this.largeImport = model.largeImport;
-    // Defaults to true so existing configurations (where the flag is absent) keep sending invitations.
-    this.inviteUsersAfterProvisioning = model.inviteUsersAfterProvisioning ?? true;
+    // Defaults to false so users are not invited unless invitations are explicitly enabled.
+    this.inviteUsersAfterProvisioning = model.inviteUsersAfterProvisioning ?? false;
   }
 }

--- a/libs/models/syncConfiguration.ts
+++ b/libs/models/syncConfiguration.ts
@@ -7,7 +7,7 @@ export class SyncConfiguration {
   removeDisabled = false;
   overwriteExisting = false;
   largeImport = false;
-  inviteUsersAfterProvisioning = true;
+  inviteUsersAfterProvisioning = false;
   // Ldap properties
   groupObjectClass: string;
   userObjectClass: string;

--- a/libs/models/syncConfiguration.ts
+++ b/libs/models/syncConfiguration.ts
@@ -7,6 +7,7 @@ export class SyncConfiguration {
   removeDisabled = false;
   overwriteExisting = false;
   largeImport = false;
+  inviteUsersAfterProvisioning = true;
   // Ldap properties
   groupObjectClass: string;
   userObjectClass: string;

--- a/libs/services/batch-request-builder.ts
+++ b/libs/services/batch-request-builder.ts
@@ -41,6 +41,7 @@ export class BatchRequestBuilder implements RequestBuilder {
           users: u,
           largeImport: true,
           overwriteExisting: false,
+          inviteUsersAfterProvisioning: options.inviteUsersAfterProvisioning,
         });
         requests.push(req);
       }
@@ -63,6 +64,7 @@ export class BatchRequestBuilder implements RequestBuilder {
           users: [],
           largeImport: true,
           overwriteExisting: false,
+          inviteUsersAfterProvisioning: options.inviteUsersAfterProvisioning,
         });
         requests.push(req);
       }

--- a/libs/services/batch-requests-builder.spec.ts
+++ b/libs/services/batch-requests-builder.spec.ts
@@ -16,7 +16,7 @@ describe("BatchRequestBuilder", () => {
   const defaultOptions: RequestBuilderOptions = Object.freeze({
     overwriteExisting: false,
     removeDisabled: false,
-    inviteUsersAfterProvisioning: true,
+    inviteUsersAfterProvisioning: false,
   });
 
   it("BatchRequestBuilder batches requests for > 2000 users", () => {
@@ -77,20 +77,20 @@ describe("BatchRequestBuilder", () => {
     const mockGroups = groupSimulator(2500);
     const mockUsers = userSimulator(2500);
 
-    const options = { ...defaultOptions, inviteUsersAfterProvisioning: false };
+    const options = { ...defaultOptions, inviteUsersAfterProvisioning: true };
     const requests = batchRequestBuilder.buildRequest(mockGroups, mockUsers, options);
 
     expect(requests.length).toBeGreaterThan(1);
-    expect(requests.every((r) => r.inviteUsersAfterProvisioning === false)).toBe(true);
+    expect(requests.every((r) => r.inviteUsersAfterProvisioning === true)).toBe(true);
   });
 
-  it("BatchRequestBuilder defaults inviteUsersAfterProvisioning to true when unset in options", () => {
+  it("BatchRequestBuilder defaults inviteUsersAfterProvisioning to false when unset in options", () => {
     const mockUsers = userSimulator(2500);
 
     // Simulate an existing configuration created before this setting existed.
     const options = { overwriteExisting: false, removeDisabled: false } as RequestBuilderOptions;
     const requests = batchRequestBuilder.buildRequest([], mockUsers, options);
 
-    expect(requests.every((r) => r.inviteUsersAfterProvisioning === true)).toBe(true);
+    expect(requests.every((r) => r.inviteUsersAfterProvisioning === false)).toBe(true);
   });
 });

--- a/libs/services/batch-requests-builder.spec.ts
+++ b/libs/services/batch-requests-builder.spec.ts
@@ -16,6 +16,7 @@ describe("BatchRequestBuilder", () => {
   const defaultOptions: RequestBuilderOptions = Object.freeze({
     overwriteExisting: false,
     removeDisabled: false,
+    inviteUsersAfterProvisioning: true,
   });
 
   it("BatchRequestBuilder batches requests for > 2000 users", () => {
@@ -70,5 +71,26 @@ describe("BatchRequestBuilder", () => {
     const requests = batchRequestBuilder.buildRequest([], [], defaultOptions);
 
     expect(requests).toEqual([]);
+  });
+
+  it("BatchRequestBuilder forwards inviteUsersAfterProvisioning from options into every partitioned request", () => {
+    const mockGroups = groupSimulator(2500);
+    const mockUsers = userSimulator(2500);
+
+    const options = { ...defaultOptions, inviteUsersAfterProvisioning: false };
+    const requests = batchRequestBuilder.buildRequest(mockGroups, mockUsers, options);
+
+    expect(requests.length).toBeGreaterThan(1);
+    expect(requests.every((r) => r.inviteUsersAfterProvisioning === false)).toBe(true);
+  });
+
+  it("BatchRequestBuilder defaults inviteUsersAfterProvisioning to true when unset in options", () => {
+    const mockUsers = userSimulator(2500);
+
+    // Simulate an existing configuration created before this setting existed.
+    const options = { overwriteExisting: false, removeDisabled: false } as RequestBuilderOptions;
+    const requests = batchRequestBuilder.buildRequest([], mockUsers, options);
+
+    expect(requests.every((r) => r.inviteUsersAfterProvisioning === true)).toBe(true);
   });
 });

--- a/libs/services/single-request-builder.spec.ts
+++ b/libs/services/single-request-builder.spec.ts
@@ -16,7 +16,7 @@ describe("SingleRequestBuilder", () => {
   const defaultOptions: RequestBuilderOptions = Object.freeze({
     overwriteExisting: false,
     removeDisabled: false,
-    inviteUsersAfterProvisioning: true,
+    inviteUsersAfterProvisioning: false,
   });
 
   it("SingleRequestBuilder returns single request for 200 users", () => {
@@ -85,13 +85,13 @@ describe("SingleRequestBuilder", () => {
     const mockGroups = groupSimulator(200);
     const mockUsers = userSimulator(200);
 
-    const options = { ...defaultOptions, inviteUsersAfterProvisioning: false };
+    const options = { ...defaultOptions, inviteUsersAfterProvisioning: true };
     const request = singleRequestBuilder.buildRequest(mockGroups, mockUsers, options)[0];
 
-    expect(request.inviteUsersAfterProvisioning).toBe(false);
+    expect(request.inviteUsersAfterProvisioning).toBe(true);
   });
 
-  it("SingleRequestBuilder defaults inviteUsersAfterProvisioning to true when unset in options", () => {
+  it("SingleRequestBuilder defaults inviteUsersAfterProvisioning to false when unset in options", () => {
     const mockGroups = groupSimulator(200);
     const mockUsers = userSimulator(200);
 
@@ -99,6 +99,6 @@ describe("SingleRequestBuilder", () => {
     const options = { overwriteExisting: false, removeDisabled: false } as RequestBuilderOptions;
     const request = singleRequestBuilder.buildRequest(mockGroups, mockUsers, options)[0];
 
-    expect(request.inviteUsersAfterProvisioning).toBe(true);
+    expect(request.inviteUsersAfterProvisioning).toBe(false);
   });
 });

--- a/libs/services/single-request-builder.spec.ts
+++ b/libs/services/single-request-builder.spec.ts
@@ -16,6 +16,7 @@ describe("SingleRequestBuilder", () => {
   const defaultOptions: RequestBuilderOptions = Object.freeze({
     overwriteExisting: false,
     removeDisabled: false,
+    inviteUsersAfterProvisioning: true,
   });
 
   it("SingleRequestBuilder returns single request for 200 users", () => {
@@ -67,12 +68,37 @@ describe("SingleRequestBuilder", () => {
     disabledUser.email = disabledUserEmail;
     mockUsers.push(disabledUser);
 
-    const options = { overwriteExisting: true, removeDisabled: true };
+    const options = {
+      overwriteExisting: true,
+      removeDisabled: true,
+      inviteUsersAfterProvisioning: true,
+    };
     const request = singleRequestBuilder.buildRequest(mockGroups, mockUsers, options)[0];
 
     expect(request.members.pop()).toEqual(
       expect.objectContaining({ email: disabledUserEmail, deleted: true }),
     );
     expect(request.overwriteExisting).toBe(true);
+  });
+
+  it("SingleRequestBuilder forwards inviteUsersAfterProvisioning from options into the request", () => {
+    const mockGroups = groupSimulator(200);
+    const mockUsers = userSimulator(200);
+
+    const options = { ...defaultOptions, inviteUsersAfterProvisioning: false };
+    const request = singleRequestBuilder.buildRequest(mockGroups, mockUsers, options)[0];
+
+    expect(request.inviteUsersAfterProvisioning).toBe(false);
+  });
+
+  it("SingleRequestBuilder defaults inviteUsersAfterProvisioning to true when unset in options", () => {
+    const mockGroups = groupSimulator(200);
+    const mockUsers = userSimulator(200);
+
+    // Simulate an existing configuration created before this setting existed.
+    const options = { overwriteExisting: false, removeDisabled: false } as RequestBuilderOptions;
+    const request = singleRequestBuilder.buildRequest(mockGroups, mockUsers, options)[0];
+
+    expect(request.inviteUsersAfterProvisioning).toBe(true);
   });
 });

--- a/libs/services/single-request-builder.ts
+++ b/libs/services/single-request-builder.ts
@@ -33,6 +33,7 @@ export class SingleRequestBuilder implements RequestBuilder {
         }),
         overwriteExisting: options.overwriteExisting,
         largeImport: false,
+        inviteUsersAfterProvisioning: options.inviteUsersAfterProvisioning,
       }),
     ];
   }

--- a/libs/services/state-service/default-state.service.spec.ts
+++ b/libs/services/state-service/default-state.service.spec.ts
@@ -455,6 +455,7 @@ describe("DefaultStateService", () => {
       removeDisabled: true,
       overwriteExisting: false,
       largeImport: false,
+      inviteUsersAfterProvisioning: true,
       groupObjectClass: null,
       userObjectClass: null,
       groupPath: null,

--- a/libs/services/state-service/default-state.service.spec.ts
+++ b/libs/services/state-service/default-state.service.spec.ts
@@ -312,6 +312,7 @@ describe("DefaultStateService", () => {
       removeDisabled: true,
       overwriteExisting: false,
       largeImport: false,
+      inviteUsersAfterProvisioning: true,
       groupObjectClass: null,
       userObjectClass: null,
       groupPath: null,

--- a/libs/services/state-service/stateMigration.service.spec.ts
+++ b/libs/services/state-service/stateMigration.service.spec.ts
@@ -42,8 +42,14 @@ describe("StateMigrationService", () => {
       expect(await svc.needsMigration()).toBe(true);
     });
 
-    it("returns false when stateVersion is StateVersion.Six (Latest)", async () => {
+    it("returns true when stateVersion is StateVersion.Six (below Latest)", async () => {
       storage.store.set(StorageKeys.stateVersion, StateVersion.Six);
+
+      expect(await svc.needsMigration()).toBe(true);
+    });
+
+    it("returns false when stateVersion is StateVersion.Seven (Latest)", async () => {
+      storage.store.set(StorageKeys.stateVersion, StateVersion.Seven);
 
       expect(await svc.needsMigration()).toBe(false);
     });
@@ -54,8 +60,8 @@ describe("StateMigrationService", () => {
       expect(await svc.needsMigration()).toBe(true);
     });
 
-    it("returns false when globals.stateVersion is StateVersion.Six (Latest)", async () => {
-      storage.store.set("global", { stateVersion: StateVersion.Six });
+    it("returns false when globals.stateVersion is StateVersion.Seven (Latest)", async () => {
+      storage.store.set("global", { stateVersion: StateVersion.Seven });
 
       expect(await svc.needsMigration()).toBe(false);
     });
@@ -81,19 +87,19 @@ describe("StateMigrationService", () => {
 
       await svc.migrate();
 
-      expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Six);
+      expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
     });
 
-    it("runs migrateStateFrom5To6 when stateVersion is StateVersion.Five", async () => {
+    it("runs remaining migrations when stateVersion is StateVersion.Five", async () => {
       storage.store.set(StorageKeys.stateVersion, StateVersion.Five);
 
       await svc.migrate();
 
-      expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Six);
+      expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
     });
 
-    it("does nothing (no extra writes) when stateVersion is already StateVersion.Six", async () => {
-      storage.store.set(StorageKeys.stateVersion, StateVersion.Six);
+    it("does nothing (no extra writes) when stateVersion is already StateVersion.Seven", async () => {
+      storage.store.set(StorageKeys.stateVersion, StateVersion.Seven);
       const storeSnapshot = new Map(storage.store);
 
       await svc.migrate();
@@ -104,13 +110,13 @@ describe("StateMigrationService", () => {
 
   describe("migrateStateFrom4To5()", () => {
     describe("no account (null activeUserId)", () => {
-      it("writes only stateVersion = Six, no other keys", async () => {
+      it("writes only stateVersion = Seven, no other keys", async () => {
         // Seed stateVersion = Four, but no activeUserId and no account data
         storage.store.set(StorageKeys.stateVersion, StateVersion.Four);
 
         await svc.migrate();
 
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Six);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
         // Only stateVersion written — nothing else
         expect(storage.store.size).toBe(1);
         expect(secureStorage.store.size).toBe(0);
@@ -195,7 +201,11 @@ describe("StateMigrationService", () => {
 
         expect(storage.store.get(StorageKeys.organizationId)).toBe("org-123");
         expect(storage.store.get(StorageKeys.directoryType)).toBe(DirectoryType.Ldap);
-        expect(storage.store.get(StorageKeys.sync)).toEqual({ users: true, groups: true });
+        expect(storage.store.get(StorageKeys.sync)).toEqual({
+          users: true,
+          groups: true,
+          inviteUsersAfterProvisioning: true,
+        });
         expect(storage.store.get(StorageKeys.syncingDir)).toBe(false);
       });
 
@@ -256,10 +266,10 @@ describe("StateMigrationService", () => {
         expect(secureStorage.store.get(SecureStorageKeys.apiKeyClientSecret)).toBe("client-secret");
       });
 
-      it("sets stateVersion to StateVersion.Six after all migrations", async () => {
+      it("sets stateVersion to StateVersion.Seven after all migrations", async () => {
         await svc.migrate();
 
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Six);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
       });
     });
 
@@ -506,7 +516,7 @@ describe("StateMigrationService", () => {
         // No window settings written
         expect(storage.store.has(StorageKeys.window)).toBe(false);
         // stateVersion still updated
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Six);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
       });
     });
 
@@ -587,10 +597,58 @@ describe("StateMigrationService", () => {
         expect(badKeys).toHaveLength(0);
       });
 
-      it("bumps stateVersion to Six", async () => {
+      it("bumps stateVersion to Seven (Latest)", async () => {
         await svc.migrate();
 
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Six);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+      });
+    });
+
+    describe("migrateStateFrom6To7()", () => {
+      beforeEach(() => {
+        storage.store.set(StorageKeys.stateVersion, StateVersion.Six);
+      });
+
+      it("backfills inviteUsersAfterProvisioning = true onto an existing sync config missing the flag", async () => {
+        storage.store.set(StorageKeys.sync, { users: true, groups: true });
+
+        await svc.migrate();
+
+        expect(storage.store.get(StorageKeys.sync)).toEqual({
+          users: true,
+          groups: true,
+          inviteUsersAfterProvisioning: true,
+        });
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+      });
+
+      it("leaves an explicit inviteUsersAfterProvisioning = false untouched", async () => {
+        storage.store.set(StorageKeys.sync, { users: true, inviteUsersAfterProvisioning: false });
+
+        await svc.migrate();
+
+        expect(storage.store.get(StorageKeys.sync)).toEqual({
+          users: true,
+          inviteUsersAfterProvisioning: false,
+        });
+      });
+
+      it("leaves an explicit inviteUsersAfterProvisioning = true untouched", async () => {
+        storage.store.set(StorageKeys.sync, { users: true, inviteUsersAfterProvisioning: true });
+
+        await svc.migrate();
+
+        expect(storage.store.get(StorageKeys.sync)).toEqual({
+          users: true,
+          inviteUsersAfterProvisioning: true,
+        });
+      });
+
+      it("does not create a sync config when none exists", async () => {
+        await svc.migrate();
+
+        expect(storage.store.has(StorageKeys.sync)).toBe(false);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
       });
     });
 
@@ -598,7 +656,7 @@ describe("StateMigrationService", () => {
       it("writes stateVersion = Latest when stateVersion is absent (fresh install)", async () => {
         await svc.stampVersion();
 
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Six);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
       });
 
       it("does not overwrite an existing stateVersion", async () => {
@@ -617,7 +675,7 @@ describe("StateMigrationService", () => {
       });
 
       it("prefers flat stateVersion key over globals.stateVersion", async () => {
-        storage.store.set(StorageKeys.stateVersion, StateVersion.Six);
+        storage.store.set(StorageKeys.stateVersion, StateVersion.Seven);
         storage.store.set("global", { stateVersion: StateVersion.Four });
 
         // Flat key wins → at latest → no migration needed

--- a/libs/services/state-service/stateMigration.service.spec.ts
+++ b/libs/services/state-service/stateMigration.service.spec.ts
@@ -60,8 +60,14 @@ describe("StateMigrationService", () => {
       expect(await svc.needsMigration()).toBe(true);
     });
 
-    it("returns false when stateVersion is StateVersion.Seven (Latest)", async () => {
+    it("returns true when stateVersion is StateVersion.Seven (below Latest)", async () => {
       storage.store.set(StorageKeys.stateVersion, StateVersion.Seven);
+
+      expect(await svc.needsMigration()).toBe(true);
+    });
+
+    it("returns false when stateVersion is StateVersion.Eight (Latest)", async () => {
+      storage.store.set(StorageKeys.stateVersion, StateVersion.Eight);
 
       expect(await svc.needsMigration()).toBe(false);
     });
@@ -72,8 +78,8 @@ describe("StateMigrationService", () => {
       expect(await svc.needsMigration()).toBe(true);
     });
 
-    it("returns false when globals.stateVersion is StateVersion.Seven (Latest)", async () => {
-      storage.store.set("global", { stateVersion: StateVersion.Seven });
+    it("returns false when globals.stateVersion is StateVersion.Eight (Latest)", async () => {
+      storage.store.set("global", { stateVersion: StateVersion.Eight });
 
       expect(await svc.needsMigration()).toBe(false);
     });
@@ -99,15 +105,15 @@ describe("StateMigrationService", () => {
 
       await svc.migrate();
 
-      expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+      expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
     });
 
-    it("runs migrateStateFrom5To6 when stateVersion is StateVersion.Five", async () => {
+    it("runs remaining migrations when stateVersion is StateVersion.Five", async () => {
       storage.store.set(StorageKeys.stateVersion, StateVersion.Five);
 
       await svc.migrate();
 
-      expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+      expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
     });
 
     it("runs migrateStateFrom6To7 when stateVersion is StateVersion.Six", async () => {
@@ -115,11 +121,11 @@ describe("StateMigrationService", () => {
 
       await svc.migrate();
 
-      expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+      expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
     });
 
-    it("does nothing (no extra writes) when stateVersion is already StateVersion.Seven", async () => {
-      storage.store.set(StorageKeys.stateVersion, StateVersion.Seven);
+    it("does nothing (no extra writes) when stateVersion is already StateVersion.Eight", async () => {
+      storage.store.set(StorageKeys.stateVersion, StateVersion.Eight);
       const storeSnapshot = new Map(storage.store);
 
       await svc.migrate();
@@ -130,13 +136,13 @@ describe("StateMigrationService", () => {
 
   describe("migrateStateFrom4To5()", () => {
     describe("no account (null activeUserId)", () => {
-      it("writes only stateVersion = Seven, no other keys", async () => {
+      it("writes only stateVersion = Eight, no other keys", async () => {
         // Seed stateVersion = Four, but no activeUserId and no account data
         storage.store.set(StorageKeys.stateVersion, StateVersion.Four);
 
         await svc.migrate();
 
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
         // Only stateVersion written — nothing else
         expect(storage.store.size).toBe(1);
         expect(secureStorage.store.size).toBe(0);
@@ -221,7 +227,11 @@ describe("StateMigrationService", () => {
 
         expect(storage.store.get(StorageKeys.organizationId)).toBe("org-123");
         expect(storage.store.get(StorageKeys.directoryType)).toBe(DirectoryType.Ldap);
-        expect(storage.store.get(StorageKeys.sync)).toEqual({ users: true, groups: true });
+        expect(storage.store.get(StorageKeys.sync)).toEqual({
+          users: true,
+          groups: true,
+          inviteUsersAfterProvisioning: true,
+        });
         expect(storage.store.get(StorageKeys.syncingDir)).toBe(false);
       });
 
@@ -282,10 +292,10 @@ describe("StateMigrationService", () => {
         expect(secureStorage.store.get(SecureStorageKeys.apiKeyClientSecret)).toBe("client-secret");
       });
 
-      it("sets stateVersion to StateVersion.Seven after all migrations", async () => {
+      it("sets stateVersion to StateVersion.Eight after all migrations", async () => {
         await svc.migrate();
 
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
       });
     });
 
@@ -532,7 +542,7 @@ describe("StateMigrationService", () => {
         // No window settings written
         expect(storage.store.has(StorageKeys.window)).toBe(false);
         // stateVersion still updated
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
       });
     });
 
@@ -613,10 +623,10 @@ describe("StateMigrationService", () => {
         expect(badKeys).toHaveLength(0);
       });
 
-      it("bumps stateVersion to Seven (5→6→7)", async () => {
+      it("bumps stateVersion to Eight (5→6→7→8)", async () => {
         await svc.migrate();
 
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
       });
 
       it("logs an error when migrateKeytarPassword returns an error field", async () => {
@@ -745,10 +755,10 @@ describe("StateMigrationService", () => {
         expect(secureStorage.store.has(`${userId}_oktaToken`)).toBe(true);
       });
 
-      it("bumps stateVersion to Seven", async () => {
+      it("bumps stateVersion to Eight (Latest)", async () => {
         await svc.migrate();
 
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
       });
 
       it("does not overwrite an existing flat key with an old {userId}_* value", async () => {
@@ -766,7 +776,7 @@ describe("StateMigrationService", () => {
         await svc.migrate();
 
         expect(secureStorage.store).toEqual(secureSnapshot);
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
       });
 
       it("skips writing a key when readKeytarPassword returns null (credential not found)", async () => {
@@ -775,7 +785,7 @@ describe("StateMigrationService", () => {
         await svc.migrate();
 
         expect(secureStorage.store.has(SecureStorageKeys.ldap)).toBe(false);
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
       });
 
       it("skips all secure storage work and just bumps version on non-Windows", async () => {
@@ -785,7 +795,7 @@ describe("StateMigrationService", () => {
         await svc.migrate();
 
         expect(secureStorage.store).toEqual(secureSnapshot);
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
       });
 
       it("skips readKeytarPassword and does not write secrets when useSecureStorageForSecrets = false (plaintext mode)", async () => {
@@ -796,7 +806,55 @@ describe("StateMigrationService", () => {
 
         expect(passwords.readKeytarPassword).not.toHaveBeenCalled();
         expect(secureStorage.store).toEqual(secureSnapshot);
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
+      });
+    });
+
+    describe("migrateStateFrom7To8()", () => {
+      beforeEach(() => {
+        storage.store.set(StorageKeys.stateVersion, StateVersion.Seven);
+      });
+
+      it("backfills inviteUsersAfterProvisioning = true onto an existing sync config missing the flag", async () => {
+        storage.store.set(StorageKeys.sync, { users: true, groups: true });
+
+        await svc.migrate();
+
+        expect(storage.store.get(StorageKeys.sync)).toEqual({
+          users: true,
+          groups: true,
+          inviteUsersAfterProvisioning: true,
+        });
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
+      });
+
+      it("leaves an explicit inviteUsersAfterProvisioning = false untouched", async () => {
+        storage.store.set(StorageKeys.sync, { users: true, inviteUsersAfterProvisioning: false });
+
+        await svc.migrate();
+
+        expect(storage.store.get(StorageKeys.sync)).toEqual({
+          users: true,
+          inviteUsersAfterProvisioning: false,
+        });
+      });
+
+      it("leaves an explicit inviteUsersAfterProvisioning = true untouched", async () => {
+        storage.store.set(StorageKeys.sync, { users: true, inviteUsersAfterProvisioning: true });
+
+        await svc.migrate();
+
+        expect(storage.store.get(StorageKeys.sync)).toEqual({
+          users: true,
+          inviteUsersAfterProvisioning: true,
+        });
+      });
+
+      it("does not create a sync config when none exists", async () => {
+        await svc.migrate();
+
+        expect(storage.store.has(StorageKeys.sync)).toBe(false);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
       });
     });
 
@@ -804,7 +862,7 @@ describe("StateMigrationService", () => {
       it("writes stateVersion = Latest when stateVersion is absent (fresh install)", async () => {
         await svc.stampVersion();
 
-        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Seven);
+        expect(storage.store.get(StorageKeys.stateVersion)).toBe(StateVersion.Eight);
       });
 
       it("does not overwrite an existing stateVersion", async () => {
@@ -823,7 +881,7 @@ describe("StateMigrationService", () => {
       });
 
       it("prefers flat stateVersion key over globals.stateVersion", async () => {
-        storage.store.set(StorageKeys.stateVersion, StateVersion.Seven);
+        storage.store.set(StorageKeys.stateVersion, StateVersion.Eight);
         storage.store.set("global", { stateVersion: StateVersion.Four });
 
         // Flat key wins → at latest → no migration needed

--- a/libs/services/state-service/stateMigration.service.ts
+++ b/libs/services/state-service/stateMigration.service.ts
@@ -61,6 +61,9 @@ export class StateMigrationService {
         case StateVersion.Five:
           await this.migrateStateFrom5To6();
           break;
+        case StateVersion.Six:
+          await this.migrateStateFrom6To7();
+          break;
       }
       currentStateVersion += 1;
     }
@@ -263,6 +266,26 @@ export class StateMigrationService {
     );
 
     await this.set(StorageKeys.stateVersion, StateVersion.Six);
+  }
+
+  /**
+   * Migrate from State v6 to v7 — preserve invitation behavior for existing installs.
+   *
+   * inviteUsersAfterProvisioning defaults to false for new installs, but installs that
+   * predate the setting always sent invitations after provisioning. If a sync configuration
+   * already exists and does not define the flag, backfill it to true so upgrading users keep
+   * their prior behavior. An explicit value (true or false) is left untouched, and configs
+   * that are absent entirely are not created. Fresh installs never reach this migration —
+   * their state version starts at Latest — so they retain the false default.
+   */
+  protected async migrateStateFrom6To7(): Promise<void> {
+    const sync = await this.get<{ inviteUsersAfterProvisioning?: boolean }>(StorageKeys.sync);
+    if (sync != null && sync.inviteUsersAfterProvisioning === undefined) {
+      sync.inviteUsersAfterProvisioning = true;
+      await this.set(StorageKeys.sync, sync);
+    }
+
+    await this.set(StorageKeys.stateVersion, StateVersion.Seven);
   }
 
   // ===================================================================

--- a/libs/services/state-service/stateMigration.service.ts
+++ b/libs/services/state-service/stateMigration.service.ts
@@ -67,6 +67,9 @@ export class StateMigrationService {
         case StateVersion.Six:
           await this.migrateStateFrom6To7();
           break;
+        case StateVersion.Seven:
+          await this.migrateStateFrom7To8();
+          break;
       }
       currentStateVersion += 1;
     }
@@ -346,6 +349,26 @@ export class StateMigrationService {
     }
 
     await this.set(StorageKeys.stateVersion, StateVersion.Seven);
+  }
+
+  /**
+   * Migrate from State v7 to v8 — preserve invitation behavior for existing installs.
+   *
+   * inviteUsersAfterProvisioning defaults to false for new installs, but installs that
+   * predate the setting always sent invitations after provisioning. If a sync configuration
+   * already exists and does not define the flag, backfill it to true so upgrading users keep
+   * their prior behavior. An explicit value (true or false) is left untouched, and configs
+   * that are absent entirely are not created. Fresh installs never reach this migration —
+   * their state version starts at Latest — so they retain the false default.
+   */
+  protected async migrateStateFrom7To8(): Promise<void> {
+    const sync = await this.get<{ inviteUsersAfterProvisioning?: boolean }>(StorageKeys.sync);
+    if (sync != null && sync.inviteUsersAfterProvisioning === undefined) {
+      sync.inviteUsersAfterProvisioning = true;
+      await this.set(StorageKeys.sync, sync);
+    }
+
+    await this.set(StorageKeys.stateVersion, StateVersion.Eight);
   }
 
   // ===================================================================

--- a/libs/services/sync.service.integration.spec.ts
+++ b/libs/services/sync.service.integration.spec.ts
@@ -130,5 +130,54 @@ describe("SyncService", () => {
       // eslint-disable-next-line no-import-assign
       constants.batchSize = originalBatchSize;
     });
+
+    it("forwards inviteUsersAfterProvisioning into the import request when disabled", async () => {
+      stateService.getDirectory
+        .calledWith(DirectoryType.Ldap)
+        .mockResolvedValue(getLdapConfiguration());
+      stateService.getSync.mockResolvedValue(
+        getSyncConfiguration({
+          users: true,
+          groups: true,
+          largeImport: false,
+          overwriteExisting: false,
+          inviteUsersAfterProvisioning: false,
+        }),
+      );
+
+      cryptoFunctionService.hash.mockResolvedValue(new ArrayBuffer(1));
+      stateService.getLastSyncHash.mockResolvedValue("unique hash");
+
+      await syncService.sync(false, false);
+
+      expect(apiService.postPublicImportDirectory).toHaveBeenCalledWith(
+        expect.objectContaining({ inviteUsersAfterProvisioning: false }),
+      );
+    });
+
+    it("defaults inviteUsersAfterProvisioning to true when unset in configuration", async () => {
+      stateService.getDirectory
+        .calledWith(DirectoryType.Ldap)
+        .mockResolvedValue(getLdapConfiguration());
+      const syncConfig = getSyncConfiguration({
+        users: true,
+        groups: true,
+        largeImport: false,
+        overwriteExisting: false,
+      });
+      // Simulate an existing configuration created before this setting existed.
+      delete (syncConfig as { inviteUsersAfterProvisioning?: boolean })
+        .inviteUsersAfterProvisioning;
+      stateService.getSync.mockResolvedValue(syncConfig);
+
+      cryptoFunctionService.hash.mockResolvedValue(new ArrayBuffer(1));
+      stateService.getLastSyncHash.mockResolvedValue("unique hash");
+
+      await syncService.sync(false, false);
+
+      expect(apiService.postPublicImportDirectory).toHaveBeenCalledWith(
+        expect.objectContaining({ inviteUsersAfterProvisioning: true }),
+      );
+    });
   });
 });

--- a/libs/services/sync.service.integration.spec.ts
+++ b/libs/services/sync.service.integration.spec.ts
@@ -131,7 +131,7 @@ describe("SyncService", () => {
       constants.batchSize = originalBatchSize;
     });
 
-    it("forwards inviteUsersAfterProvisioning into the import request when disabled", async () => {
+    it("forwards inviteUsersAfterProvisioning into the import request when enabled", async () => {
       stateService.getDirectory
         .calledWith(DirectoryType.Ldap)
         .mockResolvedValue(getLdapConfiguration());
@@ -141,7 +141,7 @@ describe("SyncService", () => {
           groups: true,
           largeImport: false,
           overwriteExisting: false,
-          inviteUsersAfterProvisioning: false,
+          inviteUsersAfterProvisioning: true,
         }),
       );
 
@@ -151,11 +151,11 @@ describe("SyncService", () => {
       await syncService.sync(false, false);
 
       expect(apiService.postPublicImportDirectory).toHaveBeenCalledWith(
-        expect.objectContaining({ inviteUsersAfterProvisioning: false }),
+        expect.objectContaining({ inviteUsersAfterProvisioning: true }),
       );
     });
 
-    it("defaults inviteUsersAfterProvisioning to true when unset in configuration", async () => {
+    it("defaults inviteUsersAfterProvisioning to false when unset in configuration", async () => {
       stateService.getDirectory
         .calledWith(DirectoryType.Ldap)
         .mockResolvedValue(getLdapConfiguration());
@@ -176,7 +176,7 @@ describe("SyncService", () => {
       await syncService.sync(false, false);
 
       expect(apiService.postPublicImportDirectory).toHaveBeenCalledWith(
-        expect.objectContaining({ inviteUsersAfterProvisioning: true }),
+        expect.objectContaining({ inviteUsersAfterProvisioning: false }),
       );
     });
   });

--- a/libs/services/sync.service.integration.spec.ts
+++ b/libs/services/sync.service.integration.spec.ts
@@ -165,7 +165,9 @@ describe("SyncService", () => {
         largeImport: false,
         overwriteExisting: false,
       });
-      // Simulate an existing configuration created before this setting existed.
+      // A config that reaches the request builder without the flag falls back to false (the
+      // safe default). Real upgraded configs are backfilled to true by the v6->v7 state
+      // migration before they ever get here (see StateMigrationService.migrateStateFrom6To7).
       delete (syncConfig as { inviteUsersAfterProvisioning?: boolean })
         .inviteUsersAfterProvisioning;
       stateService.getSync.mockResolvedValue(syncConfig);

--- a/libs/services/sync.service.spec.ts
+++ b/libs/services/sync.service.spec.ts
@@ -77,6 +77,7 @@ describe("SyncService", () => {
         groups: [],
         overwriteExisting: true,
         largeImport: true,
+        inviteUsersAfterProvisioning: true,
       },
     ];
 
@@ -159,7 +160,13 @@ describe("SyncService", () => {
       cryptoFunctionService.hash.mockResolvedValue(new ArrayBuffer(1));
       stateService.getLastSyncHash.mockResolvedValue("unique hash");
       singleRequestBuilder.buildRequest.mockReturnValue([
-        { members: [], groups: [], overwriteExisting: true, largeImport: false },
+        {
+          members: [],
+          groups: [],
+          overwriteExisting: true,
+          largeImport: false,
+          inviteUsersAfterProvisioning: true,
+        },
       ]);
     }
 
@@ -287,7 +294,13 @@ describe("SyncService", () => {
       cryptoFunctionService.hash.mockResolvedValue(new ArrayBuffer(1));
       stateService.getLastSyncHash.mockResolvedValue("unique hash");
       singleRequestBuilder.buildRequest.mockReturnValue([
-        { members: [], groups: [], overwriteExisting: true, largeImport: false },
+        {
+          members: [],
+          groups: [],
+          overwriteExisting: true,
+          largeImport: false,
+          inviteUsersAfterProvisioning: true,
+        },
       ]);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitwarden/directory-connector",
-  "version": "2026.6.0",
+  "version": "2026.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitwarden/directory-connector",
-      "version": "2026.6.0",
+      "version": "2026.6.1",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/src-cli/commands/config.command.ts
+++ b/src-cli/commands/config.command.ts
@@ -66,6 +66,9 @@ export class ConfigCommand {
         case "onelogin.secret":
           await this.setOneLoginSecret(value);
           break;
+        case "sync.inviteusersafterprovisioning":
+          await this.setInviteUsersAfterProvisioning(value);
+          break;
         default:
           return Response.badRequest("Unknown setting.");
       }
@@ -120,6 +123,16 @@ export class ConfigCommand {
   private async setOneLoginSecret(secret: string) {
     await this.loadConfig();
     this.oneLogin.clientSecret = secret;
+    await this.saveConfig();
+  }
+
+  private async setInviteUsersAfterProvisioning(value: string) {
+    const normalized = value?.toLowerCase();
+    if (normalized !== "true" && normalized !== "false") {
+      throw new Error("Value must be 'true' or 'false'.");
+    }
+    await this.loadConfig();
+    this.sync.inviteUsersAfterProvisioning = normalized === "true";
     await this.saveConfig();
   }
 

--- a/src-cli/program.ts
+++ b/src-cli/program.ts
@@ -195,6 +195,9 @@ export class Program extends BaseProgram {
         writeLn("    gsuite.key - The G Suite private key.");
         writeLn("    okta.token - The Okta token.");
         writeLn("    onelogin.secret - The OneLogin client secret.");
+        writeLn(
+          "    sync.inviteUsersAfterProvisioning - Send invitation emails to synced users (true/false).",
+        );
         writeLn("");
         writeLn("  Examples:");
         writeLn("");
@@ -207,6 +210,7 @@ export class Program extends BaseProgram {
         writeLn("    bwdc config gsuite.key <key>");
         writeLn("    bwdc config okta.token <token>");
         writeLn("    bwdc config onelogin.secret <secret>");
+        writeLn("    bwdc config sync.inviteUsersAfterProvisioning false");
         writeLn("", true);
       })
       .action(async (setting: string, value: string, options: OptionValues) => {

--- a/src-gui/app/tabs/settings.component.html
+++ b/src-gui/app/tabs/settings.component.html
@@ -562,7 +562,7 @@
               class="form-check-input"
               type="checkbox"
               id="inviteUsersAfterProvisioning"
-              [ngModel]="sync().inviteUsersAfterProvisioning ?? true"
+              [ngModel]="sync().inviteUsersAfterProvisioning ?? false"
               (ngModelChange)="sync.update(v => ({...v, inviteUsersAfterProvisioning: $event}))"
               name="InviteUsersAfterProvisioning"
             />

--- a/src-gui/app/tabs/settings.component.html
+++ b/src-gui/app/tabs/settings.component.html
@@ -556,6 +556,21 @@
             <label class="form-check-label" for="largeImport">{{ "largeImport" | i18n }}</label>
           </div>
         </div>
+        <div class="mb-3">
+          <div class="form-check">
+            <input
+              class="form-check-input"
+              type="checkbox"
+              id="inviteUsersAfterProvisioning"
+              [ngModel]="sync().inviteUsersAfterProvisioning ?? true"
+              (ngModelChange)="sync.update(v => ({...v, inviteUsersAfterProvisioning: $event}))"
+              name="InviteUsersAfterProvisioning"
+            />
+            <label class="form-check-label" for="inviteUsersAfterProvisioning">{{
+              "inviteUsersAfterProvisioning" | i18n
+            }}</label>
+          </div>
+        </div>
         <div [hidden]="directory() != directoryType.Ldap">
           <div [hidden]="ldap().ad">
             <div class="mb-3">

--- a/src-gui/app/tabs/settings.component.html
+++ b/src-gui/app/tabs/settings.component.html
@@ -563,7 +563,7 @@
               type="checkbox"
               id="inviteUsersAfterProvisioning"
               [ngModel]="sync().inviteUsersAfterProvisioning ?? false"
-              (ngModelChange)="sync.update(v => ({...v, inviteUsersAfterProvisioning: $event}))"
+              (ngModelChange)="sync.update((v) => ({ ...v, inviteUsersAfterProvisioning: $event }))"
               name="InviteUsersAfterProvisioning"
             />
             <label class="form-check-label" for="inviteUsersAfterProvisioning">{{

--- a/src-gui/locales/en/messages.json
+++ b/src-gui/locales/en/messages.json
@@ -667,6 +667,9 @@
   "overwriteExistingTooltip": {
     "message": "Learn more about Sync options"
   },
+  "inviteUsersAfterProvisioning": {
+    "message": "Automatically send email invitations"
+  },
   "clientId": {
     "message": "Client ID"
   },

--- a/utils/entra/config-fixtures.ts
+++ b/utils/entra/config-fixtures.ts
@@ -36,6 +36,7 @@ export const getSyncConfiguration = (config?: Partial<SyncConfiguration>): SyncC
   removeDisabled: false,
   overwriteExisting: false,
   largeImport: false,
+  inviteUsersAfterProvisioning: true,
   // Ldap properties - not optional for some reason
   groupObjectClass: "",
   userObjectClass: "",

--- a/utils/entra/config-fixtures.ts
+++ b/utils/entra/config-fixtures.ts
@@ -36,7 +36,7 @@ export const getSyncConfiguration = (config?: Partial<SyncConfiguration>): SyncC
   removeDisabled: false,
   overwriteExisting: false,
   largeImport: false,
-  inviteUsersAfterProvisioning: true,
+  inviteUsersAfterProvisioning: false,
   // Ldap properties - not optional for some reason
   groupObjectClass: "",
   userObjectClass: "",

--- a/utils/google-workspace/config-fixtures.ts
+++ b/utils/google-workspace/config-fixtures.ts
@@ -39,7 +39,7 @@ export const getSyncConfiguration = (config?: Partial<SyncConfiguration>): SyncC
   removeDisabled: false,
   overwriteExisting: false,
   largeImport: false,
-  inviteUsersAfterProvisioning: true,
+  inviteUsersAfterProvisioning: false,
   // Ldap properties - not optional for some reason
   groupObjectClass: "",
   userObjectClass: "",

--- a/utils/google-workspace/config-fixtures.ts
+++ b/utils/google-workspace/config-fixtures.ts
@@ -39,6 +39,7 @@ export const getSyncConfiguration = (config?: Partial<SyncConfiguration>): SyncC
   removeDisabled: false,
   overwriteExisting: false,
   largeImport: false,
+  inviteUsersAfterProvisioning: true,
   // Ldap properties - not optional for some reason
   groupObjectClass: "",
   userObjectClass: "",

--- a/utils/okta/config-fixtures.ts
+++ b/utils/okta/config-fixtures.ts
@@ -31,7 +31,7 @@ export const getSyncConfiguration = (config?: Partial<SyncConfiguration>): SyncC
   removeDisabled: false,
   overwriteExisting: false,
   largeImport: false,
-  inviteUsersAfterProvisioning: true,
+  inviteUsersAfterProvisioning: false,
   // Ldap properties - not optional for some reason
   groupObjectClass: "",
   userObjectClass: "",

--- a/utils/okta/config-fixtures.ts
+++ b/utils/okta/config-fixtures.ts
@@ -31,6 +31,7 @@ export const getSyncConfiguration = (config?: Partial<SyncConfiguration>): SyncC
   removeDisabled: false,
   overwriteExisting: false,
   largeImport: false,
+  inviteUsersAfterProvisioning: true,
   // Ldap properties - not optional for some reason
   groupObjectClass: "",
   userObjectClass: "",

--- a/utils/onelogin/config-fixtures.ts
+++ b/utils/onelogin/config-fixtures.ts
@@ -35,6 +35,7 @@ export const getSyncConfiguration = (config?: Partial<SyncConfiguration>): SyncC
   removeDisabled: false,
   overwriteExisting: false,
   largeImport: false,
+  inviteUsersAfterProvisioning: true,
   // Ldap properties - not optional for some reason
   groupObjectClass: "",
   userObjectClass: "",

--- a/utils/onelogin/config-fixtures.ts
+++ b/utils/onelogin/config-fixtures.ts
@@ -35,7 +35,7 @@ export const getSyncConfiguration = (config?: Partial<SyncConfiguration>): SyncC
   removeDisabled: false,
   overwriteExisting: false,
   largeImport: false,
-  inviteUsersAfterProvisioning: true,
+  inviteUsersAfterProvisioning: false,
   // Ldap properties - not optional for some reason
   groupObjectClass: "",
   userObjectClass: "",

--- a/utils/openldap/config-fixtures.ts
+++ b/utils/openldap/config-fixtures.ts
@@ -36,7 +36,7 @@ export const getSyncConfiguration = (config?: Partial<SyncConfiguration>): SyncC
   removeDisabled: false,
   overwriteExisting: false,
   largeImport: false,
-  inviteUsersAfterProvisioning: true,
+  inviteUsersAfterProvisioning: false,
   // Ldap properties
   groupObjectClass: "posixGroup",
   userObjectClass: "person",

--- a/utils/openldap/config-fixtures.ts
+++ b/utils/openldap/config-fixtures.ts
@@ -36,6 +36,7 @@ export const getSyncConfiguration = (config?: Partial<SyncConfiguration>): SyncC
   removeDisabled: false,
   overwriteExisting: false,
   largeImport: false,
+  inviteUsersAfterProvisioning: true,
   // Ldap properties
   groupObjectClass: "posixGroup",
   userObjectClass: "person",


### PR DESCRIPTION
## 🎟️ Tracking
[PM-37965](https://bitwarden.atlassian.net/browse/PM-37965)

## 📔 Objective
The - final - ticket for Milestone 2, this allows BWDC to specify whether or not to automatically send email invitations after provisioning. Disabling this setting will provision users in the `Staged` state.

## 📸 Screenshots
<img width="2578" height="2126" alt="image" src="https://github.com/user-attachments/assets/89e5c7a0-77ec-423c-8f05-c1277849442a" />


[PM-37965]: https://bitwarden.atlassian.net/browse/PM-37965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ