### PR TITLE
[PM-34488] directory connector not supporting multiple ad accounts on windows for multi directory sync

### DIFF
--- a/libs/models/entraIdConfiguration.ts
+++ b/libs/models/entraIdConfiguration.ts
@@ -1,6 +1,8 @@
 import { IConfiguration } from "./IConfiguration";
 
 export class EntraIdConfiguration implements IConfiguration {
+  /** Unique identifier for this specific configuration (generated automatically). See LdapConfiguration.id. */
+  id?: string;
   identityAuthority: string;
   tenant: string;
   applicationId: string;

--- a/libs/models/gsuiteConfiguration.ts
+++ b/libs/models/gsuiteConfiguration.ts
@@ -1,6 +1,8 @@
 import { IConfiguration } from "./IConfiguration";
 
 export class GSuiteConfiguration implements IConfiguration {
+  /** Unique identifier for this specific configuration (generated automatically). See LdapConfiguration.id. */
+  id?: string;
   clientEmail: string;
   privateKey: string;
   domain: string;

--- a/libs/models/ldapConfiguration.ts
+++ b/libs/models/ldapConfiguration.ts
@@ -1,6 +1,13 @@
 import { IConfiguration } from "./IConfiguration";
 
 export class LdapConfiguration implements IConfiguration {
+  /**
+   * Unique identifier for this specific configuration (generated automatically). Used to scope
+   * the secure-storage entry for `password` so that distinct configurations - e.g. two AD service
+   * accounts used for multi-directory sync - never share (or overwrite) each other's secret, even
+   * if their `data.json` files are swapped in and out on the same machine.
+   */
+  id?: string;
   ssl = false;
   startTls = false;
   tlsCaPath: string;

--- a/libs/models/oktaConfiguration.ts
+++ b/libs/models/oktaConfiguration.ts
@@ -1,6 +1,8 @@
 import { IConfiguration } from "./IConfiguration";
 
 export class OktaConfiguration implements IConfiguration {
+  /** Unique identifier for this specific configuration (generated automatically). See LdapConfiguration.id. */
+  id?: string;
   orgUrl: string;
   token: string;
 }

--- a/libs/models/oneLoginConfiguration.ts
+++ b/libs/models/oneLoginConfiguration.ts
@@ -1,6 +1,8 @@
 import { IConfiguration } from "./IConfiguration";
 
 export class OneLoginConfiguration implements IConfiguration {
+  /** Unique identifier for this specific configuration (generated automatically). See LdapConfiguration.id. */
+  id?: string;
   clientId: string;
   clientSecret: string;
   region = "us";

--- a/libs/services/state-service/default-state.service.spec.ts
+++ b/libs/services/state-service/default-state.service.spec.ts
@@ -10,13 +10,6 @@ import { SecureStorageKeys, StorageKeys, StoredSecurely } from "@/libs/models/st
 import { SyncConfiguration } from "@/libs/models/syncConfiguration";
 
 import { DefaultStateService } from "./default-state.service";
-import {
-  entraSecretSuffix,
-  gsuiteSecretSuffix,
-  ldapSecretSuffix,
-  oktaSecretSuffix,
-  oneLoginSecretSuffix,
-} from "./secret-storage-key.util";
 import { StateMigrationService } from "./stateMigration.service";
 
 import { FakeStorageService } from "@/utils/fakeStorageService";
@@ -37,6 +30,15 @@ function makeMigrationService(needsMigration = false): StateMigrationService {
     migrate: jest.fn().mockResolvedValue(undefined),
     stampVersion: jest.fn().mockResolvedValue(undefined),
   } as unknown as StateMigrationService;
+}
+
+/**
+ * Secure storage keys are scoped by a randomly-generated `id` assigned to each configuration
+ * (see secret-storage-key.util.ts), so tests look up the `id` that was actually persisted for a
+ * given directory type rather than predicting it.
+ */
+function scopedSecretKey(legacyKey: string, storedConfig: { id?: string } | null | undefined) {
+  return `${legacyKey}:${storedConfig?.id}`;
 }
 
 function makeStateService(
@@ -153,9 +155,12 @@ describe("DefaultStateService", () => {
       // Regular storage must not contain the plaintext password
       const stored = storage.store.get(StorageKeys.directoryLdap) as LdapConfiguration;
       expect(stored.password).toBe(StoredSecurely);
-      // Secure storage must hold the real password, scoped to this config's identity
-      const scopedKey = `${SecureStorageKeys.ldap}:${ldapSecretSuffix(ldapConfig)}`;
-      expect(secureStorage.store.get(scopedKey)).toBe("secret-password");
+      // The saved config is assigned a unique id, and secure storage holds the real password
+      // scoped to that id (rather than a single flat key shared by every configuration).
+      expect(stored.id).toBeTruthy();
+      expect(secureStorage.store.get(scopedSecretKey(SecureStorageKeys.ldap, stored))).toBe(
+        "secret-password",
+      );
     });
 
     it("returns null when LDAP configuration is not set", async () => {
@@ -165,10 +170,10 @@ describe("DefaultStateService", () => {
     it("removes secret from secure storage when password is null", async () => {
       // First set a password, then clear it
       await stateService.setDirectory(DirectoryType.Ldap, { ...ldapConfig });
+      const stored = storage.store.get(StorageKeys.directoryLdap) as LdapConfiguration;
       await stateService.setDirectory(DirectoryType.Ldap, { ...ldapConfig, password: null });
 
-      const scopedKey = `${SecureStorageKeys.ldap}:${ldapSecretSuffix(ldapConfig)}`;
-      expect(secureStorage.store.has(scopedKey)).toBe(false);
+      expect(secureStorage.store.has(scopedSecretKey(SecureStorageKeys.ldap, stored))).toBe(false);
       expect(secureStorage.store.has(SecureStorageKeys.ldap)).toBe(false);
     });
 
@@ -179,25 +184,85 @@ describe("DefaultStateService", () => {
       // Configure and save account 1, then swap in account 2's config (simulating
       // copying a different data.json in as described in the multi-directory workflow).
       await stateService.setDirectory(DirectoryType.Ldap, { ...account1 });
+      const savedAccount1Snapshot = {
+        ...(storage.store.get(StorageKeys.directoryLdap) as LdapConfiguration),
+      };
+
       await stateService.setDirectory(DirectoryType.Ldap, { ...account2 });
+      const savedAccount2 = storage.store.get(StorageKeys.directoryLdap) as LdapConfiguration;
+
+      // The two configurations must have been assigned different ids.
+      expect(savedAccount1Snapshot.id).not.toBe(savedAccount2.id);
 
       // Restoring account 1's (non-secret) config from an earlier data.json backup...
-      storage.store.set(StorageKeys.directoryLdap, { ...account1, password: StoredSecurely });
+      storage.store.set(StorageKeys.directoryLdap, savedAccount1Snapshot);
 
-      // ...must resolve back to account 1's password, not account 2's.
+      // ...must resolve back to account 1's password, not account 2's - even though account 2's
+      // secret was saved more recently on this machine.
       const result = await stateService.getDirectory<LdapConfiguration>(DirectoryType.Ldap);
       expect(result.username).toBe("account1");
       expect(result.password).toBe("password-one");
     });
 
+    it("keeps the same id (and secure-storage slot) when re-saving the same account, e.g. a password rotation", async () => {
+      await stateService.setDirectory(DirectoryType.Ldap, {
+        ...ldapConfig,
+        password: "password-one",
+      });
+      const firstSave = storage.store.get(StorageKeys.directoryLdap) as LdapConfiguration;
+
+      // Same hostname/domain/username, only the password changes.
+      await stateService.setDirectory(DirectoryType.Ldap, {
+        ...ldapConfig,
+        password: "password-two",
+      });
+      const secondSave = storage.store.get(StorageKeys.directoryLdap) as LdapConfiguration;
+
+      expect(secondSave.id).toBe(firstSave.id);
+      const result = await stateService.getDirectory<LdapConfiguration>(DirectoryType.Ldap);
+      expect(result.password).toBe("password-two");
+    });
+
     it("falls back to the legacy unscoped key for installs upgrading from a single shared secret", async () => {
-      // Simulate a pre-fix install: config stored with StoredSecurely, secret under the old flat key
+      // Simulate a pre-fix install: config stored with StoredSecurely (and no `id`), secret
+      // under the old flat key.
       storage.store.set(StorageKeys.directoryLdap, { ...ldapConfig, password: StoredSecurely });
       secureStorage.store.set(SecureStorageKeys.ldap, "legacy-password");
 
       const result = await stateService.getDirectory<LdapConfiguration>(DirectoryType.Ldap);
 
       expect(result.password).toBe("legacy-password");
+    });
+
+    it("migrates a legacy (pre-fix) config to a scoped id on next save, without disturbing the legacy secret still relied on by other not-yet-migrated data.json copies", async () => {
+      // Simulate an install from before this fix: config with no `id`, secret in the legacy flat
+      // key - as if account 1 had been configured on a version of the app before this change.
+      storage.store.set(StorageKeys.directoryLdap, { ...ldapConfig, password: StoredSecurely });
+      secureStorage.store.set(SecureStorageKeys.ldap, "legacy-password-account1");
+
+      // A backup copy of that legacy data.json (e.g. taken before configuring account 2 below).
+      const legacyAccount1Snapshot = {
+        ...(storage.store.get(StorageKeys.directoryLdap) as LdapConfiguration),
+      };
+
+      // The customer upgrades and configures a second account (same running app/data.json).
+      await stateService.setDirectory(DirectoryType.Ldap, {
+        ...ldapConfig,
+        username: "account2",
+        password: "password-two",
+      });
+      const savedAccount2 = storage.store.get(StorageKeys.directoryLdap) as LdapConfiguration;
+      expect(savedAccount2.id).toBeTruthy();
+
+      // The legacy flat secret must be untouched - it still holds account 1's password.
+      expect(secureStorage.store.get(SecureStorageKeys.ldap)).toBe("legacy-password-account1");
+
+      // Restoring the pre-fix account 1 backup (still without an `id`) must still resolve to
+      // account 1's password via the legacy fallback, even though account 2 was configured since.
+      storage.store.set(StorageKeys.directoryLdap, legacyAccount1Snapshot);
+      const result = await stateService.getDirectory<LdapConfiguration>(DirectoryType.Ldap);
+      expect(result.username).toBe(ldapConfig.username);
+      expect(result.password).toBe("legacy-password-account1");
     });
   });
 
@@ -219,8 +284,10 @@ describe("DefaultStateService", () => {
       expect(result.privateKey).toBe("private-key-content");
       const stored = storage.store.get(StorageKeys.directoryGsuite) as GSuiteConfiguration;
       expect(stored.privateKey).toBe(StoredSecurely);
-      const scopedKey = `${SecureStorageKeys.gsuite}:${gsuiteSecretSuffix(gsuiteConfig)}`;
-      expect(secureStorage.store.get(scopedKey)).toBe("private-key-content");
+      expect(stored.id).toBeTruthy();
+      expect(secureStorage.store.get(scopedSecretKey(SecureStorageKeys.gsuite, stored))).toBe(
+        "private-key-content",
+      );
     });
 
     it("normalizes escaped newlines in privateKey", async () => {
@@ -229,17 +296,21 @@ describe("DefaultStateService", () => {
         ...gsuiteConfig,
         privateKey: keyWithEscapedNewlines,
       });
+      const stored = storage.store.get(StorageKeys.directoryGsuite) as GSuiteConfiguration;
 
-      const scopedKey = `${SecureStorageKeys.gsuite}:${gsuiteSecretSuffix(gsuiteConfig)}`;
-      expect(secureStorage.store.get(scopedKey)).toBe("line1\nline2\nline3");
+      expect(secureStorage.store.get(scopedSecretKey(SecureStorageKeys.gsuite, stored))).toBe(
+        "line1\nline2\nline3",
+      );
     });
 
     it("removes secret from secure storage when privateKey is null", async () => {
       await stateService.setDirectory(DirectoryType.GSuite, { ...gsuiteConfig });
+      const stored = storage.store.get(StorageKeys.directoryGsuite) as GSuiteConfiguration;
       await stateService.setDirectory(DirectoryType.GSuite, { ...gsuiteConfig, privateKey: null });
 
-      const scopedKey = `${SecureStorageKeys.gsuite}:${gsuiteSecretSuffix(gsuiteConfig)}`;
-      expect(secureStorage.store.has(scopedKey)).toBe(false);
+      expect(secureStorage.store.has(scopedSecretKey(SecureStorageKeys.gsuite, stored))).toBe(
+        false,
+      );
       expect(secureStorage.store.has(SecureStorageKeys.gsuite)).toBe(false);
     });
   });
@@ -261,8 +332,10 @@ describe("DefaultStateService", () => {
       expect(result.key).toBe("secret-key");
       const stored = storage.store.get(StorageKeys.directoryEntra) as EntraIdConfiguration;
       expect(stored.key).toBe(StoredSecurely);
-      const scopedKey = `${SecureStorageKeys.entra}:${entraSecretSuffix(entraConfig)}`;
-      expect(secureStorage.store.get(scopedKey)).toBe("secret-key");
+      expect(stored.id).toBeTruthy();
+      expect(secureStorage.store.get(scopedSecretKey(SecureStorageKeys.entra, stored))).toBe(
+        "secret-key",
+      );
     });
 
     it("falls back to legacy azure key when entra key is absent", async () => {
@@ -291,10 +364,16 @@ describe("DefaultStateService", () => {
       const tenant2 = { ...entraConfig, tenant: "tenant-two", key: "key-two" };
 
       await stateService.setDirectory(DirectoryType.EntraID, { ...tenant1 });
+      const savedTenant1Snapshot = {
+        ...(storage.store.get(StorageKeys.directoryEntra) as EntraIdConfiguration),
+      };
+
       await stateService.setDirectory(DirectoryType.EntraID, { ...tenant2 });
+      const savedTenant2 = storage.store.get(StorageKeys.directoryEntra) as EntraIdConfiguration;
+      expect(savedTenant1Snapshot.id).not.toBe(savedTenant2.id);
 
       // Restoring tenant 1's (non-secret) config from an earlier data.json backup...
-      storage.store.set(StorageKeys.directoryEntra, { ...tenant1, key: StoredSecurely });
+      storage.store.set(StorageKeys.directoryEntra, savedTenant1Snapshot);
 
       const result = await stateService.getDirectory<EntraIdConfiguration>(DirectoryType.EntraID);
       expect(result.tenant).toBe("tenant-one");
@@ -317,8 +396,10 @@ describe("DefaultStateService", () => {
       expect(result.token).toBe("okta-token");
       const stored = storage.store.get(StorageKeys.directoryOkta) as OktaConfiguration;
       expect(stored.token).toBe(StoredSecurely);
-      const scopedKey = `${SecureStorageKeys.okta}:${oktaSecretSuffix(oktaConfig)}`;
-      expect(secureStorage.store.get(scopedKey)).toBe("okta-token");
+      expect(stored.id).toBeTruthy();
+      expect(secureStorage.store.get(scopedSecretKey(SecureStorageKeys.okta, stored))).toBe(
+        "okta-token",
+      );
     });
   });
 
@@ -338,8 +419,10 @@ describe("DefaultStateService", () => {
       expect(result.clientSecret).toBe("client-secret");
       const stored = storage.store.get(StorageKeys.directoryOnelogin) as OneLoginConfiguration;
       expect(stored.clientSecret).toBe(StoredSecurely);
-      const scopedKey = `${SecureStorageKeys.oneLogin}:${oneLoginSecretSuffix(oneLoginConfig)}`;
-      expect(secureStorage.store.get(scopedKey)).toBe("client-secret");
+      expect(stored.id).toBeTruthy();
+      expect(secureStorage.store.get(scopedSecretKey(SecureStorageKeys.oneLogin, stored))).toBe(
+        "client-secret",
+      );
     });
   });
 

--- a/libs/services/state-service/default-state.service.spec.ts
+++ b/libs/services/state-service/default-state.service.spec.ts
@@ -10,6 +10,13 @@ import { SecureStorageKeys, StorageKeys, StoredSecurely } from "@/libs/models/st
 import { SyncConfiguration } from "@/libs/models/syncConfiguration";
 
 import { DefaultStateService } from "./default-state.service";
+import {
+  entraSecretSuffix,
+  gsuiteSecretSuffix,
+  ldapSecretSuffix,
+  oktaSecretSuffix,
+  oneLoginSecretSuffix,
+} from "./secret-storage-key.util";
 import { StateMigrationService } from "./stateMigration.service";
 
 import { FakeStorageService } from "@/utils/fakeStorageService";
@@ -146,8 +153,9 @@ describe("DefaultStateService", () => {
       // Regular storage must not contain the plaintext password
       const stored = storage.store.get(StorageKeys.directoryLdap) as LdapConfiguration;
       expect(stored.password).toBe(StoredSecurely);
-      // Secure storage must hold the real password
-      expect(secureStorage.store.get(SecureStorageKeys.ldap)).toBe("secret-password");
+      // Secure storage must hold the real password, scoped to this config's identity
+      const scopedKey = `${SecureStorageKeys.ldap}:${ldapSecretSuffix(ldapConfig)}`;
+      expect(secureStorage.store.get(scopedKey)).toBe("secret-password");
     });
 
     it("returns null when LDAP configuration is not set", async () => {
@@ -159,7 +167,37 @@ describe("DefaultStateService", () => {
       await stateService.setDirectory(DirectoryType.Ldap, { ...ldapConfig });
       await stateService.setDirectory(DirectoryType.Ldap, { ...ldapConfig, password: null });
 
+      const scopedKey = `${SecureStorageKeys.ldap}:${ldapSecretSuffix(ldapConfig)}`;
+      expect(secureStorage.store.has(scopedKey)).toBe(false);
       expect(secureStorage.store.has(SecureStorageKeys.ldap)).toBe(false);
+    });
+
+    it("keeps secrets for two different LDAP configs (e.g. two AD service accounts) isolated", async () => {
+      const account1 = { ...ldapConfig, username: "account1", password: "password-one" };
+      const account2 = { ...ldapConfig, username: "account2", password: "password-two" };
+
+      // Configure and save account 1, then swap in account 2's config (simulating
+      // copying a different data.json in as described in the multi-directory workflow).
+      await stateService.setDirectory(DirectoryType.Ldap, { ...account1 });
+      await stateService.setDirectory(DirectoryType.Ldap, { ...account2 });
+
+      // Restoring account 1's (non-secret) config from an earlier data.json backup...
+      storage.store.set(StorageKeys.directoryLdap, { ...account1, password: StoredSecurely });
+
+      // ...must resolve back to account 1's password, not account 2's.
+      const result = await stateService.getDirectory<LdapConfiguration>(DirectoryType.Ldap);
+      expect(result.username).toBe("account1");
+      expect(result.password).toBe("password-one");
+    });
+
+    it("falls back to the legacy unscoped key for installs upgrading from a single shared secret", async () => {
+      // Simulate a pre-fix install: config stored with StoredSecurely, secret under the old flat key
+      storage.store.set(StorageKeys.directoryLdap, { ...ldapConfig, password: StoredSecurely });
+      secureStorage.store.set(SecureStorageKeys.ldap, "legacy-password");
+
+      const result = await stateService.getDirectory<LdapConfiguration>(DirectoryType.Ldap);
+
+      expect(result.password).toBe("legacy-password");
     });
   });
 
@@ -181,7 +219,8 @@ describe("DefaultStateService", () => {
       expect(result.privateKey).toBe("private-key-content");
       const stored = storage.store.get(StorageKeys.directoryGsuite) as GSuiteConfiguration;
       expect(stored.privateKey).toBe(StoredSecurely);
-      expect(secureStorage.store.get(SecureStorageKeys.gsuite)).toBe("private-key-content");
+      const scopedKey = `${SecureStorageKeys.gsuite}:${gsuiteSecretSuffix(gsuiteConfig)}`;
+      expect(secureStorage.store.get(scopedKey)).toBe("private-key-content");
     });
 
     it("normalizes escaped newlines in privateKey", async () => {
@@ -191,13 +230,16 @@ describe("DefaultStateService", () => {
         privateKey: keyWithEscapedNewlines,
       });
 
-      expect(secureStorage.store.get(SecureStorageKeys.gsuite)).toBe("line1\nline2\nline3");
+      const scopedKey = `${SecureStorageKeys.gsuite}:${gsuiteSecretSuffix(gsuiteConfig)}`;
+      expect(secureStorage.store.get(scopedKey)).toBe("line1\nline2\nline3");
     });
 
     it("removes secret from secure storage when privateKey is null", async () => {
       await stateService.setDirectory(DirectoryType.GSuite, { ...gsuiteConfig });
       await stateService.setDirectory(DirectoryType.GSuite, { ...gsuiteConfig, privateKey: null });
 
+      const scopedKey = `${SecureStorageKeys.gsuite}:${gsuiteSecretSuffix(gsuiteConfig)}`;
+      expect(secureStorage.store.has(scopedKey)).toBe(false);
       expect(secureStorage.store.has(SecureStorageKeys.gsuite)).toBe(false);
     });
   });
@@ -219,7 +261,8 @@ describe("DefaultStateService", () => {
       expect(result.key).toBe("secret-key");
       const stored = storage.store.get(StorageKeys.directoryEntra) as EntraIdConfiguration;
       expect(stored.key).toBe(StoredSecurely);
-      expect(secureStorage.store.get(SecureStorageKeys.entra)).toBe("secret-key");
+      const scopedKey = `${SecureStorageKeys.entra}:${entraSecretSuffix(entraConfig)}`;
+      expect(secureStorage.store.get(scopedKey)).toBe("secret-key");
     });
 
     it("falls back to legacy azure key when entra key is absent", async () => {
@@ -242,6 +285,21 @@ describe("DefaultStateService", () => {
       expect(secureStorage.store.has(SecureStorageKeys.entra)).toBe(false);
       expect(secureStorage.store.has(SecureStorageKeys.azure)).toBe(false);
     });
+
+    it("keeps secrets for two different Entra configs (e.g. two tenants) isolated", async () => {
+      const tenant1 = { ...entraConfig, tenant: "tenant-one", key: "key-one" };
+      const tenant2 = { ...entraConfig, tenant: "tenant-two", key: "key-two" };
+
+      await stateService.setDirectory(DirectoryType.EntraID, { ...tenant1 });
+      await stateService.setDirectory(DirectoryType.EntraID, { ...tenant2 });
+
+      // Restoring tenant 1's (non-secret) config from an earlier data.json backup...
+      storage.store.set(StorageKeys.directoryEntra, { ...tenant1, key: StoredSecurely });
+
+      const result = await stateService.getDirectory<EntraIdConfiguration>(DirectoryType.EntraID);
+      expect(result.tenant).toBe("tenant-one");
+      expect(result.key).toBe("key-one");
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -259,7 +317,8 @@ describe("DefaultStateService", () => {
       expect(result.token).toBe("okta-token");
       const stored = storage.store.get(StorageKeys.directoryOkta) as OktaConfiguration;
       expect(stored.token).toBe(StoredSecurely);
-      expect(secureStorage.store.get(SecureStorageKeys.okta)).toBe("okta-token");
+      const scopedKey = `${SecureStorageKeys.okta}:${oktaSecretSuffix(oktaConfig)}`;
+      expect(secureStorage.store.get(scopedKey)).toBe("okta-token");
     });
   });
 
@@ -279,7 +338,8 @@ describe("DefaultStateService", () => {
       expect(result.clientSecret).toBe("client-secret");
       const stored = storage.store.get(StorageKeys.directoryOnelogin) as OneLoginConfiguration;
       expect(stored.clientSecret).toBe(StoredSecurely);
-      expect(secureStorage.store.get(SecureStorageKeys.oneLogin)).toBe("client-secret");
+      const scopedKey = `${SecureStorageKeys.oneLogin}:${oneLoginSecretSuffix(oneLoginConfig)}`;
+      expect(secureStorage.store.get(scopedKey)).toBe("client-secret");
     });
   });
 

--- a/libs/services/state-service/default-state.service.ts
+++ b/libs/services/state-service/default-state.service.ts
@@ -18,11 +18,12 @@ import { SyncConfiguration } from "@/libs/models/syncConfiguration";
 
 import { StateService } from "./default-state.service";
 import {
-  entraSecretSuffix,
-  gsuiteSecretSuffix,
-  ldapSecretSuffix,
-  oktaSecretSuffix,
-  oneLoginSecretSuffix,
+  entraConfigsShareIdentity,
+  generateConfigId,
+  gsuiteConfigsShareIdentity,
+  ldapConfigsShareIdentity,
+  oktaConfigsShareIdentity,
+  oneLoginConfigsShareIdentity,
 } from "./secret-storage-key.util";
 import { StateMigrationService } from "./stateMigration.service";
 
@@ -101,6 +102,11 @@ export class DefaultStateService implements StateService {
       switch (type) {
         case DirectoryType.Ldap: {
           const ldapConfig = config as LdapConfiguration;
+          const previous = await this.getLdapConfiguration();
+          ldapConfig.id = this.resolveConfigId(
+            previous,
+            ldapConfigsShareIdentity(previous, ldapConfig),
+          );
           await this.setLdapSecret(ldapConfig, ldapConfig.password);
           ldapConfig.password = StoredSecurely;
           await this.setLdapConfiguration(ldapConfig);
@@ -108,6 +114,11 @@ export class DefaultStateService implements StateService {
         }
         case DirectoryType.EntraID: {
           const entraConfig = config as EntraIdConfiguration;
+          const previous = await this.getEntraConfiguration();
+          entraConfig.id = this.resolveConfigId(
+            previous,
+            entraConfigsShareIdentity(previous, entraConfig),
+          );
           await this.setEntraSecret(entraConfig, entraConfig.key);
           entraConfig.key = StoredSecurely;
           await this.setEntraConfiguration(entraConfig);
@@ -115,6 +126,11 @@ export class DefaultStateService implements StateService {
         }
         case DirectoryType.Okta: {
           const oktaConfig = config as OktaConfiguration;
+          const previous = await this.getOktaConfiguration();
+          oktaConfig.id = this.resolveConfigId(
+            previous,
+            oktaConfigsShareIdentity(previous, oktaConfig),
+          );
           await this.setOktaSecret(oktaConfig, oktaConfig.token);
           oktaConfig.token = StoredSecurely;
           await this.setOktaConfiguration(oktaConfig);
@@ -122,6 +138,11 @@ export class DefaultStateService implements StateService {
         }
         case DirectoryType.GSuite: {
           const gsuiteConfig = config as GSuiteConfiguration;
+          const previous = await this.getGsuiteConfiguration();
+          gsuiteConfig.id = this.resolveConfigId(
+            previous,
+            gsuiteConfigsShareIdentity(previous, gsuiteConfig),
+          );
           if (gsuiteConfig.privateKey == null) {
             await this.setGsuiteSecret(gsuiteConfig, null);
           } else {
@@ -134,6 +155,11 @@ export class DefaultStateService implements StateService {
         }
         case DirectoryType.OneLogin: {
           const oneLoginConfig = config as OneLoginConfiguration;
+          const previous = await this.getOneLoginConfiguration();
+          oneLoginConfig.id = this.resolveConfigId(
+            previous,
+            oneLoginConfigsShareIdentity(previous, oneLoginConfig),
+          );
           await this.setOneLoginSecret(oneLoginConfig, oneLoginConfig.clientSecret);
           oneLoginConfig.clientSecret = StoredSecurely;
           await this.setOneLoginConfiguration(oneLoginConfig);
@@ -181,24 +207,43 @@ export class DefaultStateService implements StateService {
   // ===================================================================
 
   /**
-   * Builds a secure storage key scoped to a specific configuration's identity (e.g. hostname
-   * + username for LDAP), falling back to the given legacy/unscoped key when no identity is
-   * available. This keeps secrets for distinct configurations (e.g. two AD service accounts)
-   * from colliding in OS secure storage. See secret-storage-key.util.ts for details.
+   * Decides the `id` a configuration should be saved with: the previous configuration's id is
+   * reused when the new configuration represents the same account/identity (e.g. a password
+   * rotation), otherwise a fresh id is generated (e.g. switching to a different AD service
+   * account). Keeping the id stable across identity-preserving saves means the secure-storage
+   * slot is updated in place rather than accumulating a new orphaned entry on every save.
    */
-  private scopedSecretKey(legacyKey: SecureStorageKey, suffix: string): SecureStorageKey {
-    return `${legacyKey}:${suffix}` as SecureStorageKey;
+  private resolveConfigId(
+    previous: { id?: string } | null | undefined,
+    sameIdentity: boolean,
+  ): string {
+    if (sameIdentity && previous?.id != null) {
+      return previous.id;
+    }
+    return generateConfigId();
+  }
+
+  /**
+   * Builds a secure storage key scoped to a specific configuration's `id`, falling back to the
+   * given legacy/unscoped key when no id is available. This keeps secrets for distinct
+   * configurations (e.g. two AD service accounts) from colliding in OS secure storage. See
+   * secret-storage-key.util.ts for details.
+   */
+  private scopedSecretKey(legacyKey: SecureStorageKey, id: string): SecureStorageKey {
+    return `${legacyKey}:${id}` as SecureStorageKey;
   }
 
   private async getScopedSecret(
     legacyKey: SecureStorageKey,
-    suffix: string,
+    id: string | null | undefined,
   ): Promise<string | null> {
-    const scoped = await this.secureStorageService.get<string>(
-      this.scopedSecretKey(legacyKey, suffix),
-    );
-    if (scoped != null) {
-      return scoped;
+    if (id != null) {
+      const scoped = await this.secureStorageService.get<string>(
+        this.scopedSecretKey(legacyKey, id),
+      );
+      if (scoped != null) {
+        return scoped;
+      }
     }
     // Fall back to the legacy, unscoped key for installs upgrading from a version that stored
     // a single shared secret per directory type, regardless of which configuration was active.
@@ -207,70 +252,70 @@ export class DefaultStateService implements StateService {
 
   private async setScopedSecret(
     legacyKey: SecureStorageKey,
-    suffix: string,
+    id: string | null | undefined,
     value: string,
   ): Promise<void> {
-    const scopedKey = this.scopedSecretKey(legacyKey, suffix);
+    const key = id != null ? this.scopedSecretKey(legacyKey, id) : legacyKey;
     if (value == null) {
-      await this.secureStorageService.remove(scopedKey);
+      await this.secureStorageService.remove(key);
       // Also clear the legacy unscoped key so clearing a secret always fully clears it,
       // even if it hadn't been migrated to a scoped key yet.
-      await this.secureStorageService.remove(legacyKey);
+      if (id != null) {
+        await this.secureStorageService.remove(legacyKey);
+      }
     } else {
-      await this.secureStorageService.save(scopedKey, value);
+      await this.secureStorageService.save(key, value);
     }
   }
 
   private async getLdapSecret(config: LdapConfiguration): Promise<string> {
-    return await this.getScopedSecret(SecureStorageKeys.ldap, ldapSecretSuffix(config));
+    return await this.getScopedSecret(SecureStorageKeys.ldap, config?.id);
   }
 
   private async setLdapSecret(config: LdapConfiguration, value: string): Promise<void> {
-    await this.setScopedSecret(SecureStorageKeys.ldap, ldapSecretSuffix(config), value);
+    await this.setScopedSecret(SecureStorageKeys.ldap, config.id, value);
   }
 
   private async getGsuiteSecret(config: GSuiteConfiguration): Promise<string> {
-    return await this.getScopedSecret(SecureStorageKeys.gsuite, gsuiteSecretSuffix(config));
+    return await this.getScopedSecret(SecureStorageKeys.gsuite, config?.id);
   }
 
   private async setGsuiteSecret(config: GSuiteConfiguration, value: string): Promise<void> {
-    await this.setScopedSecret(SecureStorageKeys.gsuite, gsuiteSecretSuffix(config), value);
+    await this.setScopedSecret(SecureStorageKeys.gsuite, config.id, value);
   }
 
   private async getEntraSecret(config: EntraIdConfiguration): Promise<string> {
-    const suffix = entraSecretSuffix(config);
-    const entraKey = await this.getScopedSecret(SecureStorageKeys.entra, suffix);
+    const entraKey = await this.getScopedSecret(SecureStorageKeys.entra, config?.id);
     if (entraKey != null) {
       return entraKey;
     }
     // Try new key first, fall back to old azure key for backwards compatibility
-    return await this.getScopedSecret(SecureStorageKeys.azure, suffix);
+    return await this.getScopedSecret(SecureStorageKeys.azure, config?.id);
   }
 
   private async setEntraSecret(config: EntraIdConfiguration, value: string): Promise<void> {
-    const suffix = entraSecretSuffix(config);
     if (value == null) {
-      await this.setScopedSecret(SecureStorageKeys.entra, suffix, null);
-      await this.setScopedSecret(SecureStorageKeys.azure, suffix, null);
+      await this.setScopedSecret(SecureStorageKeys.entra, config.id, null);
+      await this.setScopedSecret(SecureStorageKeys.azure, config.id, null);
     } else {
-      await this.setScopedSecret(SecureStorageKeys.entra, suffix, value);
+      await this.setScopedSecret(SecureStorageKeys.entra, config.id, value);
     }
   }
 
   private async getOktaSecret(config: OktaConfiguration): Promise<string> {
-    return await this.getScopedSecret(SecureStorageKeys.okta, oktaSecretSuffix(config));
+    return await this.getScopedSecret(SecureStorageKeys.okta, config?.id);
   }
 
   private async setOktaSecret(config: OktaConfiguration, value: string): Promise<void> {
-    await this.setScopedSecret(SecureStorageKeys.okta, oktaSecretSuffix(config), value);
+    await this.setScopedSecret(SecureStorageKeys.okta, config.id, value);
   }
 
   private async getOneLoginSecret(config: OneLoginConfiguration): Promise<string> {
-    return await this.getScopedSecret(SecureStorageKeys.oneLogin, oneLoginSecretSuffix(config));
+    return await this.getScopedSecret(SecureStorageKeys.oneLogin, config?.id);
   }
 
   private async setOneLoginSecret(config: OneLoginConfiguration, value: string): Promise<void> {
-    await this.setScopedSecret(SecureStorageKeys.oneLogin, oneLoginSecretSuffix(config), value);
+    await this.setScopedSecret(SecureStorageKeys.oneLogin, config.id, value);
   }
 
   // ===================================================================

--- a/libs/services/state-service/default-state.service.ts
+++ b/libs/services/state-service/default-state.service.ts
@@ -8,10 +8,22 @@ import { GSuiteConfiguration } from "@/libs/models/gsuiteConfiguration";
 import { LdapConfiguration } from "@/libs/models/ldapConfiguration";
 import { OktaConfiguration } from "@/libs/models/oktaConfiguration";
 import { OneLoginConfiguration } from "@/libs/models/oneLoginConfiguration";
-import { SecureStorageKeys, StorageKeys, StoredSecurely } from "@/libs/models/state.model";
+import {
+  SecureStorageKey,
+  SecureStorageKeys,
+  StorageKeys,
+  StoredSecurely,
+} from "@/libs/models/state.model";
 import { SyncConfiguration } from "@/libs/models/syncConfiguration";
 
 import { StateService } from "./default-state.service";
+import {
+  entraSecretSuffix,
+  gsuiteSecretSuffix,
+  ldapSecretSuffix,
+  oktaSecretSuffix,
+  oneLoginSecretSuffix,
+} from "./secret-storage-key.util";
 import { StateMigrationService } from "./stateMigration.service";
 
 export class DefaultStateService implements StateService {
@@ -46,19 +58,27 @@ export class DefaultStateService implements StateService {
 
       switch (type) {
         case DirectoryType.Ldap:
-          (configWithSecrets as any).password = await this.getLdapSecret();
+          (configWithSecrets as any).password = await this.getLdapSecret(
+            config as LdapConfiguration,
+          );
           break;
         case DirectoryType.EntraID:
-          (configWithSecrets as any).key = await this.getEntraSecret();
+          (configWithSecrets as any).key = await this.getEntraSecret(
+            config as EntraIdConfiguration,
+          );
           break;
         case DirectoryType.Okta:
-          (configWithSecrets as any).token = await this.getOktaSecret();
+          (configWithSecrets as any).token = await this.getOktaSecret(config as OktaConfiguration);
           break;
         case DirectoryType.GSuite:
-          (configWithSecrets as any).privateKey = await this.getGsuiteSecret();
+          (configWithSecrets as any).privateKey = await this.getGsuiteSecret(
+            config as GSuiteConfiguration,
+          );
           break;
         case DirectoryType.OneLogin:
-          (configWithSecrets as any).clientSecret = await this.getOneLoginSecret();
+          (configWithSecrets as any).clientSecret = await this.getOneLoginSecret(
+            config as OneLoginConfiguration,
+          );
           break;
       }
 
@@ -81,21 +101,21 @@ export class DefaultStateService implements StateService {
       switch (type) {
         case DirectoryType.Ldap: {
           const ldapConfig = config as LdapConfiguration;
-          await this.setLdapSecret(ldapConfig.password);
+          await this.setLdapSecret(ldapConfig, ldapConfig.password);
           ldapConfig.password = StoredSecurely;
           await this.setLdapConfiguration(ldapConfig);
           break;
         }
         case DirectoryType.EntraID: {
           const entraConfig = config as EntraIdConfiguration;
-          await this.setEntraSecret(entraConfig.key);
+          await this.setEntraSecret(entraConfig, entraConfig.key);
           entraConfig.key = StoredSecurely;
           await this.setEntraConfiguration(entraConfig);
           break;
         }
         case DirectoryType.Okta: {
           const oktaConfig = config as OktaConfiguration;
-          await this.setOktaSecret(oktaConfig.token);
+          await this.setOktaSecret(oktaConfig, oktaConfig.token);
           oktaConfig.token = StoredSecurely;
           await this.setOktaConfiguration(oktaConfig);
           break;
@@ -103,10 +123,10 @@ export class DefaultStateService implements StateService {
         case DirectoryType.GSuite: {
           const gsuiteConfig = config as GSuiteConfiguration;
           if (gsuiteConfig.privateKey == null) {
-            await this.setGsuiteSecret(null);
+            await this.setGsuiteSecret(gsuiteConfig, null);
           } else {
             const normalizedPrivateKey = gsuiteConfig.privateKey.replace(/\\n/g, "\n");
-            await this.setGsuiteSecret(normalizedPrivateKey);
+            await this.setGsuiteSecret(gsuiteConfig, normalizedPrivateKey);
             gsuiteConfig.privateKey = StoredSecurely;
           }
           await this.setGsuiteConfiguration(gsuiteConfig);
@@ -114,7 +134,7 @@ export class DefaultStateService implements StateService {
         }
         case DirectoryType.OneLogin: {
           const oneLoginConfig = config as OneLoginConfiguration;
-          await this.setOneLoginSecret(oneLoginConfig.clientSecret);
+          await this.setOneLoginSecret(oneLoginConfig, oneLoginConfig.clientSecret);
           oneLoginConfig.clientSecret = StoredSecurely;
           await this.setOneLoginConfiguration(oneLoginConfig);
           break;
@@ -160,70 +180,97 @@ export class DefaultStateService implements StateService {
   // Secret Storage Methods (Secure Storage)
   // ===================================================================
 
-  private async getLdapSecret(): Promise<string> {
-    return await this.secureStorageService.get<string>(SecureStorageKeys.ldap);
+  /**
+   * Builds a secure storage key scoped to a specific configuration's identity (e.g. hostname
+   * + username for LDAP), falling back to the given legacy/unscoped key when no identity is
+   * available. This keeps secrets for distinct configurations (e.g. two AD service accounts)
+   * from colliding in OS secure storage. See secret-storage-key.util.ts for details.
+   */
+  private scopedSecretKey(legacyKey: SecureStorageKey, suffix: string): SecureStorageKey {
+    return `${legacyKey}:${suffix}` as SecureStorageKey;
   }
 
-  private async setLdapSecret(value: string): Promise<void> {
+  private async getScopedSecret(
+    legacyKey: SecureStorageKey,
+    suffix: string,
+  ): Promise<string | null> {
+    const scoped = await this.secureStorageService.get<string>(
+      this.scopedSecretKey(legacyKey, suffix),
+    );
+    if (scoped != null) {
+      return scoped;
+    }
+    // Fall back to the legacy, unscoped key for installs upgrading from a version that stored
+    // a single shared secret per directory type, regardless of which configuration was active.
+    return await this.secureStorageService.get<string>(legacyKey);
+  }
+
+  private async setScopedSecret(
+    legacyKey: SecureStorageKey,
+    suffix: string,
+    value: string,
+  ): Promise<void> {
+    const scopedKey = this.scopedSecretKey(legacyKey, suffix);
     if (value == null) {
-      await this.secureStorageService.remove(SecureStorageKeys.ldap);
+      await this.secureStorageService.remove(scopedKey);
+      // Also clear the legacy unscoped key so clearing a secret always fully clears it,
+      // even if it hadn't been migrated to a scoped key yet.
+      await this.secureStorageService.remove(legacyKey);
     } else {
-      await this.secureStorageService.save(SecureStorageKeys.ldap, value);
+      await this.secureStorageService.save(scopedKey, value);
     }
   }
 
-  private async getGsuiteSecret(): Promise<string> {
-    return await this.secureStorageService.get<string>(SecureStorageKeys.gsuite);
+  private async getLdapSecret(config: LdapConfiguration): Promise<string> {
+    return await this.getScopedSecret(SecureStorageKeys.ldap, ldapSecretSuffix(config));
   }
 
-  private async setGsuiteSecret(value: string): Promise<void> {
-    if (value == null) {
-      await this.secureStorageService.remove(SecureStorageKeys.gsuite);
-    } else {
-      await this.secureStorageService.save(SecureStorageKeys.gsuite, value);
-    }
+  private async setLdapSecret(config: LdapConfiguration, value: string): Promise<void> {
+    await this.setScopedSecret(SecureStorageKeys.ldap, ldapSecretSuffix(config), value);
   }
 
-  private async getEntraSecret(): Promise<string> {
-    // Try new key first, fall back to old azure key for backwards compatibility
-    const entraKey = await this.secureStorageService.get<string>(SecureStorageKeys.entra);
+  private async getGsuiteSecret(config: GSuiteConfiguration): Promise<string> {
+    return await this.getScopedSecret(SecureStorageKeys.gsuite, gsuiteSecretSuffix(config));
+  }
+
+  private async setGsuiteSecret(config: GSuiteConfiguration, value: string): Promise<void> {
+    await this.setScopedSecret(SecureStorageKeys.gsuite, gsuiteSecretSuffix(config), value);
+  }
+
+  private async getEntraSecret(config: EntraIdConfiguration): Promise<string> {
+    const suffix = entraSecretSuffix(config);
+    const entraKey = await this.getScopedSecret(SecureStorageKeys.entra, suffix);
     if (entraKey != null) {
       return entraKey;
     }
-    return await this.secureStorageService.get<string>(SecureStorageKeys.azure);
+    // Try new key first, fall back to old azure key for backwards compatibility
+    return await this.getScopedSecret(SecureStorageKeys.azure, suffix);
   }
 
-  private async setEntraSecret(value: string): Promise<void> {
+  private async setEntraSecret(config: EntraIdConfiguration, value: string): Promise<void> {
+    const suffix = entraSecretSuffix(config);
     if (value == null) {
-      await this.secureStorageService.remove(SecureStorageKeys.entra);
-      await this.secureStorageService.remove(SecureStorageKeys.azure);
+      await this.setScopedSecret(SecureStorageKeys.entra, suffix, null);
+      await this.setScopedSecret(SecureStorageKeys.azure, suffix, null);
     } else {
-      await this.secureStorageService.save(SecureStorageKeys.entra, value);
+      await this.setScopedSecret(SecureStorageKeys.entra, suffix, value);
     }
   }
 
-  private async getOktaSecret(): Promise<string> {
-    return await this.secureStorageService.get<string>(SecureStorageKeys.okta);
+  private async getOktaSecret(config: OktaConfiguration): Promise<string> {
+    return await this.getScopedSecret(SecureStorageKeys.okta, oktaSecretSuffix(config));
   }
 
-  private async setOktaSecret(value: string): Promise<void> {
-    if (value == null) {
-      await this.secureStorageService.remove(SecureStorageKeys.okta);
-    } else {
-      await this.secureStorageService.save(SecureStorageKeys.okta, value);
-    }
+  private async setOktaSecret(config: OktaConfiguration, value: string): Promise<void> {
+    await this.setScopedSecret(SecureStorageKeys.okta, oktaSecretSuffix(config), value);
   }
 
-  private async getOneLoginSecret(): Promise<string> {
-    return await this.secureStorageService.get<string>(SecureStorageKeys.oneLogin);
+  private async getOneLoginSecret(config: OneLoginConfiguration): Promise<string> {
+    return await this.getScopedSecret(SecureStorageKeys.oneLogin, oneLoginSecretSuffix(config));
   }
 
-  private async setOneLoginSecret(value: string): Promise<void> {
-    if (value == null) {
-      await this.secureStorageService.remove(SecureStorageKeys.oneLogin);
-    } else {
-      await this.secureStorageService.save(SecureStorageKeys.oneLogin, value);
-    }
+  private async setOneLoginSecret(config: OneLoginConfiguration, value: string): Promise<void> {
+    await this.setScopedSecret(SecureStorageKeys.oneLogin, oneLoginSecretSuffix(config), value);
   }
 
   // ===================================================================

--- a/libs/services/state-service/secret-storage-key.util.ts
+++ b/libs/services/state-service/secret-storage-key.util.ts
@@ -1,0 +1,61 @@
+import * as crypto from "crypto";
+
+import { EntraIdConfiguration } from "@/libs/models/entraIdConfiguration";
+import { GSuiteConfiguration } from "@/libs/models/gsuiteConfiguration";
+import { LdapConfiguration } from "@/libs/models/ldapConfiguration";
+import { OktaConfiguration } from "@/libs/models/oktaConfiguration";
+import { OneLoginConfiguration } from "@/libs/models/oneLoginConfiguration";
+
+/**
+ * `data.json` can be freely copied between machines/environments to manage multiple
+ * directory configurations (e.g. one per AD domain or service account) - this is a
+ * documented, supported workflow. However, secrets (passwords, API keys, tokens, etc.)
+ * are never written to `data.json`; they live in OS-native secure storage (Windows
+ * Credential Manager, macOS Keychain, libsecret, etc.) under a single fixed key per
+ * directory type.
+ *
+ * Because that key was not tied to *which* configuration it belonged to, swapping in
+ * a different `data.json` would correctly restore the non-secret fields (hostname,
+ * username, tenant, etc.) but the secure-storage lookup would still return whichever
+ * secret was most recently saved on that machine - silently mixing the username from
+ * one configuration with the secret from another.
+ *
+ * To fix this, secure storage keys are suffixed with a hash derived from the
+ * non-secret fields that identify a given configuration. Distinct configurations
+ * (e.g. two AD service accounts, or two Okta orgs) each get their own slot in secure
+ * storage, so switching `data.json` files also switches which secret is read back.
+ */
+function identitySuffix(parts: (string | null | undefined)[]): string {
+  const normalized = parts.map((part) => (part ?? "").trim().toLowerCase()).join("\u0000");
+  return crypto.createHash("sha256").update(normalized, "utf8").digest("hex").slice(0, 16);
+}
+
+export function ldapSecretSuffix(
+  config: Pick<LdapConfiguration, "hostname" | "domain" | "username"> | null | undefined,
+): string {
+  return identitySuffix([config?.hostname, config?.domain, config?.username]);
+}
+
+export function entraSecretSuffix(
+  config: Pick<EntraIdConfiguration, "tenant" | "applicationId"> | null | undefined,
+): string {
+  return identitySuffix([config?.tenant, config?.applicationId]);
+}
+
+export function oktaSecretSuffix(
+  config: Pick<OktaConfiguration, "orgUrl"> | null | undefined,
+): string {
+  return identitySuffix([config?.orgUrl]);
+}
+
+export function gsuiteSecretSuffix(
+  config: Pick<GSuiteConfiguration, "clientEmail" | "domain" | "customer"> | null | undefined,
+): string {
+  return identitySuffix([config?.clientEmail, config?.domain, config?.customer]);
+}
+
+export function oneLoginSecretSuffix(
+  config: Pick<OneLoginConfiguration, "clientId" | "region"> | null | undefined,
+): string {
+  return identitySuffix([config?.clientId, config?.region]);
+}

--- a/libs/services/state-service/secret-storage-key.util.ts
+++ b/libs/services/state-service/secret-storage-key.util.ts
@@ -7,55 +7,88 @@ import { OktaConfiguration } from "@/libs/models/oktaConfiguration";
 import { OneLoginConfiguration } from "@/libs/models/oneLoginConfiguration";
 
 /**
- * `data.json` can be freely copied between machines/environments to manage multiple
- * directory configurations (e.g. one per AD domain or service account) - this is a
- * documented, supported workflow. However, secrets (passwords, API keys, tokens, etc.)
- * are never written to `data.json`; they live in OS-native secure storage (Windows
- * Credential Manager, macOS Keychain, libsecret, etc.) under a single fixed key per
- * directory type.
+ * `data.json` can be freely copied between machines/environments to manage multiple directory
+ * configurations (e.g. one per AD domain or service account) - this is a documented, supported
+ * workflow. However, secrets (passwords, API keys, tokens, etc.) are never written to
+ * `data.json`; they live in OS-native secure storage (Windows Credential Manager, macOS
+ * Keychain, libsecret, etc.) under a single fixed key per directory type.
  *
- * Because that key was not tied to *which* configuration it belonged to, swapping in
- * a different `data.json` would correctly restore the non-secret fields (hostname,
- * username, tenant, etc.) but the secure-storage lookup would still return whichever
- * secret was most recently saved on that machine - silently mixing the username from
- * one configuration with the secret from another.
+ * Because that key was not tied to *which* configuration it belonged to, swapping in a
+ * different `data.json` would correctly restore the non-secret fields (hostname, username,
+ * tenant, etc.) but the secure-storage lookup would still return whichever secret was most
+ * recently saved on that machine - silently mixing the username from one configuration with the
+ * secret from another.
  *
- * To fix this, secure storage keys are suffixed with a hash derived from the
- * non-secret fields that identify a given configuration. Distinct configurations
- * (e.g. two AD service accounts, or two Okta orgs) each get their own slot in secure
- * storage, so switching `data.json` files also switches which secret is read back.
+ * The fix: each configuration carries its own randomly-generated `id`, and secure storage keys
+ * are suffixed with that `id`. Distinct configurations (e.g. two AD service accounts, or two
+ * Okta orgs pointed at the same Bitwarden organization) each get their own slot in secure
+ * storage, so switching `data.json` files also switches which secret is read back. The `id` is
+ * intentionally *not* derived from the Bitwarden organization id - customers may legitimately
+ * run multiple directory configurations (different directories/service accounts) against the
+ * same organization, and those must not collide either.
+ *
+ * The `id` is kept stable across saves as long as the configuration's identity (the fields
+ * below) hasn't changed, so routine actions like rotating a password for the same account
+ * update the existing secure-storage slot in place rather than minting a new one every time
+ * settings are saved.
  */
-function identitySuffix(parts: (string | null | undefined)[]): string {
-  const normalized = parts.map((part) => (part ?? "").trim().toLowerCase()).join("\u0000");
-  return crypto.createHash("sha256").update(normalized, "utf8").digest("hex").slice(0, 16);
+export function generateConfigId(): string {
+  return crypto.randomUUID();
 }
 
-export function ldapSecretSuffix(
-  config: Pick<LdapConfiguration, "hostname" | "domain" | "username"> | null | undefined,
-): string {
-  return identitySuffix([config?.hostname, config?.domain, config?.username]);
+function fieldsMatch(a: unknown, b: unknown): boolean {
+  return (a ?? null) === (b ?? null);
 }
 
-export function entraSecretSuffix(
-  config: Pick<EntraIdConfiguration, "tenant" | "applicationId"> | null | undefined,
-): string {
-  return identitySuffix([config?.tenant, config?.applicationId]);
+export function ldapConfigsShareIdentity(
+  previous: Pick<LdapConfiguration, "hostname" | "domain" | "username"> | null | undefined,
+  next: Pick<LdapConfiguration, "hostname" | "domain" | "username"> | null | undefined,
+): boolean {
+  return (
+    previous != null &&
+    fieldsMatch(previous.hostname, next?.hostname) &&
+    fieldsMatch(previous.domain, next?.domain) &&
+    fieldsMatch(previous.username, next?.username)
+  );
 }
 
-export function oktaSecretSuffix(
-  config: Pick<OktaConfiguration, "orgUrl"> | null | undefined,
-): string {
-  return identitySuffix([config?.orgUrl]);
+export function entraConfigsShareIdentity(
+  previous: Pick<EntraIdConfiguration, "tenant" | "applicationId"> | null | undefined,
+  next: Pick<EntraIdConfiguration, "tenant" | "applicationId"> | null | undefined,
+): boolean {
+  return (
+    previous != null &&
+    fieldsMatch(previous.tenant, next?.tenant) &&
+    fieldsMatch(previous.applicationId, next?.applicationId)
+  );
 }
 
-export function gsuiteSecretSuffix(
-  config: Pick<GSuiteConfiguration, "clientEmail" | "domain" | "customer"> | null | undefined,
-): string {
-  return identitySuffix([config?.clientEmail, config?.domain, config?.customer]);
+export function oktaConfigsShareIdentity(
+  previous: Pick<OktaConfiguration, "orgUrl"> | null | undefined,
+  next: Pick<OktaConfiguration, "orgUrl"> | null | undefined,
+): boolean {
+  return previous != null && fieldsMatch(previous.orgUrl, next?.orgUrl);
 }
 
-export function oneLoginSecretSuffix(
-  config: Pick<OneLoginConfiguration, "clientId" | "region"> | null | undefined,
-): string {
-  return identitySuffix([config?.clientId, config?.region]);
+export function gsuiteConfigsShareIdentity(
+  previous: Pick<GSuiteConfiguration, "clientEmail" | "domain" | "customer"> | null | undefined,
+  next: Pick<GSuiteConfiguration, "clientEmail" | "domain" | "customer"> | null | undefined,
+): boolean {
+  return (
+    previous != null &&
+    fieldsMatch(previous.clientEmail, next?.clientEmail) &&
+    fieldsMatch(previous.domain, next?.domain) &&
+    fieldsMatch(previous.customer, next?.customer)
+  );
+}
+
+export function oneLoginConfigsShareIdentity(
+  previous: Pick<OneLoginConfiguration, "clientId" | "region"> | null | undefined,
+  next: Pick<OneLoginConfiguration, "clientId" | "region"> | null | undefined,
+): boolean {
+  return (
+    previous != null &&
+    fieldsMatch(previous.clientId, next?.clientId) &&
+    fieldsMatch(previous.region, next?.region)
+  );
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34488

## 📔 Objective

Introduces a ID to configs for the directory secrets, so Secure Storage will get the secret along with the id rather than using a single shared key every time directory connector runs.
