### PR TITLE
[PM-39788] Add workflow to automatically label a PR by change type

### DIFF
--- a/.github/label-pr.json
+++ b/.github/label-pr.json
@@ -1,0 +1,22 @@
+{
+  "title_patterns": {
+    "t:feature": ["feat", "feature", "tool"],
+    "t:bugfix": ["fix", "bug", "bugfix"],
+    "t:tech-debt": ["refactor", "chore", "cleanup", "revert", "debt", "test", "perf"],
+    "t:docs": ["docs"],
+    "t:ci": ["ci", "build", "chore(ci)"],
+    "t:deps": ["deps", "[deps]"],
+    "t:breaking-change": ["breaking", "breaking-change"],
+    "t:misc": ["misc"],
+    "t:llm": ["llm"]
+  },
+  "path_patterns": {
+    "feature-flag": [],
+    "t:feature": [],
+    "t:tech-debt": [],
+    "t:ci": [".checkmarx/", ".github/", "scripts/"],
+    "t:docs": ["README.md", "CONTRIBUTING.md", "SECURITY.md"],
+    "t:deps": [],
+    "t:llm": [".claude/"]
+  }
+}

--- a/.github/label-pr.json
+++ b/.github/label-pr.json
@@ -14,7 +14,7 @@
     "feature-flag": [],
     "t:feature": [],
     "t:tech-debt": [],
-    "t:ci": [".checkmarx/", ".github/", "scripts/"],
+    "t:ci": [".checkmarx/", ".github/"],
     "t:docs": ["README.md", "CONTRIBUTING.md", "SECURITY.md"],
     "t:deps": [],
     "t:llm": [".claude/"]

--- a/.github/label-pr.json
+++ b/.github/label-pr.json
@@ -11,7 +11,6 @@
     "t:llm": ["llm"]
   },
   "path_patterns": {
-    "feature-flag": [],
     "t:feature": [],
     "t:tech-debt": [],
     "t:ci": [".checkmarx/", ".github/"],

--- a/.github/workflows/auto-label-pr-sdlc.yml
+++ b/.github/workflows/auto-label-pr-sdlc.yml
@@ -1,0 +1,29 @@
+name: Label PR
+run-name: Label PR #${{ github.event.pull_request.number }}
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  label:
+    name: Label PR
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Label PR
+        uses: bitwarden/gh-actions/auto-label-pr-sdlc@main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          pr-labels: ${{ toJSON(github.event.pull_request.labels) }}
+          mode: add
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-label-pr-sdlc.yml
+++ b/.github/workflows/auto-label-pr-sdlc.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39788

Depends on https://github.com/bitwarden/gh-actions/pull/829
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds a workflow that gets triggered when a PR is opened, synchronized or re-opened. It calls a composite action living in bitwarden/gh-actions and passes the PR number and any existing labels to it. The composite action looks for a configuration file (`.github/label-pr.json`) and tries to match the change type via PR title and/or changed files.

It then applies one of the labels `t:*` to the PR.

These change type labels are then used to create categories for the Github release notes.