### PR TITLE
[BRE-2116] Add bypass flag to directory-connector pull_request_target build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Get Package Version
         id: retrieve-version
@@ -76,6 +77,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Node Environment
         uses: ./.github/actions/setup-node-env
@@ -146,6 +148,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Node Environment
         uses: ./.github/actions/setup-node-env
@@ -274,6 +277,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Windows builder
         run: choco install checksum --no-progress
@@ -339,6 +343,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Node Environment
         uses: ./.github/actions/setup-node-env
@@ -450,6 +455,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Node Environment
         uses: ./.github/actions/setup-node-env
@@ -502,6 +508,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Node Environment
         uses: ./.github/actions/setup-node-env
@@ -635,6 +642,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Node Environment
         uses: ./.github/actions/setup-node-env


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-2116

## 📔 Objective

Adds `allow-unsafe-pr-checkout: true` to the 8 fork-checkout steps in `build.yml` (already on checkout `v7.0.0`).

`build.yml` runs via `build-target.yml` (`pull_request_target`) and checks out fork `head.sha` to build/sign artifacts. checkout v7 refuses that fork checkout by default; without this flag the fork-PR build path is broken.

Regression-prevention only — this preserves existing behavior and does NOT remediate the underlying pwn-request exposure (fork code running in a privileged context). Remediation is scoped in the follow-up spike.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
